### PR TITLE
fix pre-startup crash

### DIFF
--- a/crates/bevy_flair_style/src/lib.rs
+++ b/crates/bevy_flair_style/src/lib.rs
@@ -285,10 +285,8 @@ impl Plugin for FlairStylePlugin {
                     StyleSystemSets::EmitAnimationEvents.after(StyleSystemSets::ComputeProperties),
                 ),
             )
-            .add_systems(PreStartup, |mut commands: Commands| {
-                commands.init_resource::<EmptyComputedProperties>();
-                commands.init_resource::<InitialPropertyValues>();
-            })
+            .init_resource::<EmptyComputedProperties>()
+            .init_resource::<InitialPropertyValues>()
             .add_systems(
                 PreUpdate,
                 (


### PR DESCRIPTION
I was experiencing a crash on startup when adding this plugin to my project.

Backtrace:

```
thread 'main' panicked at /home/ada/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_flair_style-0.3.0/src/components.rs:426:43:
Requested resource bevy_flair_style::components::EmptyComputedProperties does not exist in the `World`.
                Did you forget to add it using `app.insert_resource` / `app.init_resource`?
                Resources are also implicitly added via `app.add_event`,
                and can be added by plugins.
```

I noticed that the initialization for EmptyComputedProperties was happening on PreStartup, so I moved it to the top-level. That fixed it.

If there's a specific reason you left those in PreStartup, let me know! Happy to discuss further.