### PR TITLE
Export `parse_duration` and `cssparser`

### DIFF
--- a/crates/bevy_flair_css_parser/src/lib.rs
+++ b/crates/bevy_flair_css_parser/src/lib.rs
@@ -19,6 +19,7 @@ pub use reflect::*;
 pub use shorthand::*;
 
 pub use calc::{CalcAdd, CalcMul, Calculable, parse_calc_property_value_with, parse_calc_value};
+pub use parser::parse_duration;
 pub use utils::parse_property_value_with;
 
 mod error;

--- a/crates/bevy_flair_css_parser/src/parser.rs
+++ b/crates/bevy_flair_css_parser/src/parser.rs
@@ -156,7 +156,26 @@ pub enum CssStyleSheetItem {
     Error(CssError),
 }
 
-fn parse_duration(parser: &mut Parser) -> Result<Duration, CssError> {
+/// Parses a [`Duration`] from a CSS token.
+///
+/// This function recognizes two types of values:
+///
+/// - `<number>s` → [`Duration::from_secs_f32`]
+/// - `<number>ms` → [`Duration::from_millis`]
+///
+/// # Example
+///
+/// ```
+/// # use std::time::Duration;
+/// # use cssparser::{Parser, ParserInput};
+/// # use bevy_flair_css_parser::parse_duration;
+///
+/// let mut input = ParserInput::new("3.0s");
+/// let mut parser = Parser::new(&mut input);
+/// let duration = parse_duration(&mut parser).unwrap();
+/// assert_eq!(duration, Duration::from_secs_f32(3.0));
+/// ```
+pub fn parse_duration(parser: &mut Parser) -> Result<Duration, CssError> {
     let next = parser.located_next()?;
 
     Ok(match &*next {


### PR DESCRIPTION
Custom properties are nice although it's an under-documented feature. Upon registering my own property `-lifetime: 5s` I figured I need to parse `std::time::Duration` somehow. Turns out, it's already in the library. So I made it public and added docs w/ a small example.

Also re-exported `cssparse`, because otherwise I can only pass closures to `ReflectParseCss`, because `Parser` is inaccessible (and it seems odd to depend on `cssparser` library for my package) 

---
P.S. Absolutely love this library !