### PR TITLE
Add support for `-bevy-image-rect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Support for the css properties:
+  - `-bevy-image-rect`
+
 ## [0.5.1] - 11-Oct-2025
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It enables you to style UI components, taking advantage of the power of CSS.
   - Shorthand properties parse into individual properties, like `margin` becomes `margin-left`, `margin-right`, etc.
   - Transitions and animations are supported for shorthand properties as well.
 - Non-standard CSS extensions for [`ImageNode`] 
-  - Example: `background-image: url("panel-border-030.png")`, `-bevy-image-mode: sliced(20.0px)`.
+  - Example: `background-image: url("panel-border-030.png")`, `-bevy-image-mode: sliced(20.0px)`, `-bevy-image-rect: 0 0 64 64`.
 - Color parsing. (e.g. `red`,`#ff0000`,`rgb(255 0 0)`,`hsl(0 100% 50% / 50%)`,`oklch(40.1% 0.123 21.57)`)
 - Common CSS selectors and combinators (via [selectors] crate):
   - `:root`, `#id` (using [`Name`]), `.class` (using [`ClassList`]), type selectors (via [`TypeName`]), `:hover`, `:active`, `:focus`, `:nth-child`, `:first-child`.

--- a/crates/bevy_flair_core/src/lib.rs
+++ b/crates/bevy_flair_core/src/lib.rs
@@ -145,6 +145,7 @@ default_properties! {
     "-bevy-image" { insert_if_missing: ImageNode[".image"] },
     "-bevy-image-color" { insert_if_missing: ImageNode[".color"] },
     "-bevy-image-mode" { insert_if_missing: ImageNode[".image_mode"] },
+    "-bevy-image-rect" { insert_if_missing: ImageNode[".rect"] },
 
     // Text fields
     "color" inherit { TextColor[".0"] },

--- a/crates/bevy_flair_css_parser/src/reflect.rs
+++ b/crates/bevy_flair_css_parser/src/reflect.rs
@@ -20,7 +20,7 @@ use crate::error::CssError;
 use bevy_app::{App, Plugin};
 use bevy_flair_core::{ComponentPropertyId, ComponentPropertyRef, PropertyValue};
 use bevy_flair_style::{DynamicParseVarTokens, ToCss};
-use bevy_math::{Rot2, Vec2};
+use bevy_math::{Rect, Rot2, Vec2};
 use bevy_text::{FontSmoothing, Justify, LineBreak, LineHeight};
 use bevy_ui::widget::NodeImageMode;
 
@@ -114,9 +114,11 @@ impl Plugin for ReflectParsePlugin {
                 Val,
                 Val2,
                 Rot2,
+                Rect,
                 bevy_color::Color,
                 OverflowClipMargin,
                 Option<f32>,
+                Option<Rect>,
                 ZIndex,
                 bevy_asset::Handle<bevy_image::Image>,
                 bevy_asset::Handle<bevy_text::Font>,

--- a/tests/css/all_properties.css
+++ b/tests/css/all_properties.css
@@ -48,6 +48,7 @@
 
     -bevy-image-color: yellow;
     -bevy-image-mode: stretch;
+    -bevy-image-rect: 0 0 64 64;
 
     background-image: linear-gradient(90deg, red, blue);
     border-image: radial-gradient(at center, red, blue);
@@ -102,6 +103,7 @@
 
     -bevy-image-color: yellow !important;
     -bevy-image-mode: stretch !important;
+    -bevy-image-rect: 0 0 64 64 !important;
 
     background-image: linear-gradient(90deg, red, blue) !important;
     border-image: radial-gradient(at center, red, blue) !important;
@@ -155,6 +157,7 @@
     transform: inherit;
     -bevy-image-color: inherit;
     -bevy-image-mode: inherit;
+    -bevy-image-rect: inherit;
     background-image: inherit;
     border-image: inherit;
 }
@@ -206,6 +209,7 @@
     transform: initial;
     -bevy-image-color: initial;
     -bevy-image-mode: initial;
+    -bevy-image-rect: initial;
     background-image: initial;
     border-image: initial;
 }


### PR DESCRIPTION
Add support for a new property for `ImageNode::rect`: `-bevy-image-rect`. Also add a parser for `Rect` and `Option<Rect>`, which this property uses.