### PR TITLE
Allowing `Name` to be used for dynamic ui content

### DIFF
--- a/crates/bevy_flair_style/src/components.rs
+++ b/crates/bevy_flair_style/src/components.rs
@@ -1274,12 +1274,10 @@ pub struct TypeName(pub &'static str);
 fn on_insert_type_name(mut world: DeferredWorld, context: HookContext) {
     let entity = context.entity;
     let new_type_name = world.get::<TypeName>(entity).unwrap().0;
-    let Some(mut style_data) = world
-        .get_mut::<NodeStyleData>(entity) else {
-            tracing::error!("TypeName without NodeStyleData (ignore if you use `Name::new(...)` for dynamic content)");
-            return;
-        };
-        
+    let Some(mut style_data) = world.get_mut::<NodeStyleData>(entity) else {
+        tracing::error!("TypeName without NodeStyleData");
+        return;
+    };
 
     if let Some(type_name) = style_data.type_name {
         panic!(


### PR DESCRIPTION
Hi!
I am currently using your cool library.
I want to use your styling selectors (`Name`) for dynamic content, because it simplifys stuff in my proc macro, and i don't need to create another datastructure.
I unfortinitly run into this error:  
```rust
ERROR my_app: Panic!: panicked at C:\Users\me_name\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\bevy_flair_style-0.6.0\src\components.rs:1103:10:
TypeName without NodeStyleData
```
I implemented that the error is ignored (but still logged).