### PR TITLE
Experimental Cursor Property

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,6 +663,7 @@ dependencies = [
  "bevy_reflect",
  "bevy_text",
  "bevy_ui",
+ "bevy_window",
  "cssparser",
  "cssparser-color",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,7 @@ dependencies = [
  "bevy_reflect",
  "bevy_text",
  "bevy_ui",
+ "bevy_window",
  "rustc-hash 2.1.1",
  "serde",
  "thiserror 2.0.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,8 @@ dependencies = [
  "bevy_flair_core",
  "bevy_flair_css_parser",
  "bevy_flair_style",
+ "bevy_window",
+ "bevy_winit",
  "criterion",
  "cssparser",
  "getrandom",
@@ -1411,7 +1413,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f582478606d6b6e5c53befbe7612f038fdfb73f8a27f7aae644406637347acd4"
 dependencies = [
  "bevy_app",
+ "bevy_asset",
  "bevy_ecs",
+ "bevy_image",
  "bevy_input",
  "bevy_math",
  "bevy_platform",
@@ -1433,8 +1437,10 @@ dependencies = [
  "bevy_a11y",
  "bevy_android",
  "bevy_app",
+ "bevy_asset",
  "bevy_derive",
  "bevy_ecs",
+ "bevy_image",
  "bevy_input",
  "bevy_input_focus",
  "bevy_log",
@@ -1443,10 +1449,12 @@ dependencies = [
  "bevy_reflect",
  "bevy_tasks",
  "bevy_window",
+ "bytemuck",
  "cfg-if",
  "tracing",
  "wasm-bindgen",
  "web-sys",
+ "wgpu-types",
  "winit",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,11 +55,15 @@ bevy_flair_css_parser = { workspace = true }
 [features]
 default = []
 experimental_ghost_nodes = ["bevy_flair_style/experimental_ghost_nodes"]
-experimental_cursor_property = ["bevy_flair_core/experimental_cursor_property", "bevy_flair_css_parser/experimental_cursor_property"]
+experimental_cursor_property = [
+"bevy_flair_core/experimental_cursor_property",
+"bevy_flair_css_parser/experimental_cursor_property"
+]
 experimental_cursor_custom = [
     "dep:bevy_window", "bevy_window/custom_cursor",
     "dep:bevy_winit", "bevy_winit/custom_cursor",
-    "bevy_flair_core/experimental_cursor_custom"
+    "bevy_flair_core/experimental_cursor_custom",
+    "bevy_flair_css_parser/experimental_cursor_custom"
 ]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ bevy_flair_css_parser = { workspace = true }
 [features]
 default = []
 experimental_ghost_nodes = ["bevy_flair_style/experimental_ghost_nodes"]
-experimental_cursor_property = []
+experimental_cursor_property = ["bevy_flair_core/experimental_cursor_property"]
 
 [dev-dependencies]
 criterion = { version = "0.7", default-features = false, features = [ "plotters", "cargo_bench_support","html_reports" ] }
@@ -99,3 +99,7 @@ opt-level = 0
 
 [profile.dev.package.bevy_ui]
 opt-level = 1
+
+[[example]]
+name = "buttons_cursor"
+required-features = ["experimental_cursor_property"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ selectors = { version = "0.32" }
 [dependencies]
 bevy_app = { workspace = true }
 bevy_ecs = { workspace = true }
+bevy_window = { workspace = true, optional = true }
+bevy_winit = { version = "0.17", optional = true }
 
 bevy_flair_core = { workspace = true }
 bevy_flair_style = { workspace = true }
@@ -54,6 +56,11 @@ bevy_flair_css_parser = { workspace = true }
 default = []
 experimental_ghost_nodes = ["bevy_flair_style/experimental_ghost_nodes"]
 experimental_cursor_property = ["bevy_flair_core/experimental_cursor_property", "bevy_flair_css_parser/experimental_cursor_property"]
+experimental_cursor_custom = [
+    "dep:bevy_window", "bevy_window/custom_cursor",
+    "dep:bevy_winit", "bevy_winit/custom_cursor",
+    "bevy_flair_core/experimental_cursor_custom"
+]
 
 [dev-dependencies]
 criterion = { version = "0.7", default-features = false, features = [ "plotters", "cargo_bench_support","html_reports" ] }
@@ -102,4 +109,4 @@ opt-level = 1
 
 [[example]]
 name = "buttons_cursor"
-required-features = ["experimental_cursor_property"]
+required-features = ["experimental_cursor_property", "experimental_cursor_custom"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ bevy_flair_css_parser = { workspace = true }
 [features]
 default = []
 experimental_ghost_nodes = ["bevy_flair_style/experimental_ghost_nodes"]
+experimental_cursor_property = []
 
 [dev-dependencies]
 criterion = { version = "0.7", default-features = false, features = [ "plotters", "cargo_bench_support","html_reports" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ bevy_flair_css_parser = { workspace = true }
 [features]
 default = []
 experimental_ghost_nodes = ["bevy_flair_style/experimental_ghost_nodes"]
-experimental_cursor_property = ["bevy_flair_core/experimental_cursor_property"]
+experimental_cursor_property = ["bevy_flair_core/experimental_cursor_property", "bevy_flair_css_parser/experimental_cursor_property"]
 
 [dev-dependencies]
 criterion = { version = "0.7", default-features = false, features = [ "plotters", "cargo_bench_support","html_reports" ] }

--- a/assets/buttons_cursor.css
+++ b/assets/buttons_cursor.css
@@ -10,5 +10,5 @@ button {
 
 button:not(.dark-light-button):active {
     -bevy-cursor-image: url("panel-border-010.png");
-    -bevy-cursor-image-rect: true;
+    -bevy-cursor-image-rect: 0 0 48 48;
 }

--- a/assets/buttons_cursor.css
+++ b/assets/buttons_cursor.css
@@ -9,5 +9,7 @@ button {
 }
 
 button:not(.dark-light-button):active {
-    cursor: url("panel-border-010.png");
+    -bevy-cursor-image: url("panel-border-010.png");
+    -bevy-cursor-image-hotspot-x: 48;
+    -bevy-cursor-image-hotspot-y: 48;
 }

--- a/assets/buttons_cursor.css
+++ b/assets/buttons_cursor.css
@@ -1,0 +1,5 @@
+@import "buttons.css";
+
+button {
+    cursor: pointer;
+}

--- a/assets/buttons_cursor.css
+++ b/assets/buttons_cursor.css
@@ -1,7 +1,7 @@
 @import "buttons.css";
 
 button {
-    -bevy-cursor-system: pointer;
+    cursor: pointer;
 
     &:active {
         cursor: grabbing;
@@ -10,4 +10,6 @@ button {
 
 button:not(.dark-light-button):active {
     cursor: url("panel-border-010.png");
+    -bevy-cursor-image-hotspot-x: 48;
+    -bevy-cursor-image-hotspot-y: 48;
 }

--- a/assets/buttons_cursor.css
+++ b/assets/buttons_cursor.css
@@ -9,6 +9,5 @@ button {
 }
 
 button:not(.dark-light-button):active {
-    -bevy-cursor-image: url("panel-border-010.png");
-    -bevy-cursor-image-rect: 0 0 48 48;
+    cursor: url("panel-border-010.png");
 }

--- a/assets/buttons_cursor.css
+++ b/assets/buttons_cursor.css
@@ -10,6 +10,5 @@ button {
 
 button:not(.dark-light-button):active {
     -bevy-cursor-image: url("panel-border-010.png");
-    -bevy-cursor-image-hotspot-x: 48;
-    -bevy-cursor-image-hotspot-y: 48;
+    -bevy-cursor-image-rect: true;
 }

--- a/assets/buttons_cursor.css
+++ b/assets/buttons_cursor.css
@@ -1,7 +1,7 @@
 @import "buttons.css";
 
 button {
-    cursor: pointer;
+    -bevy-cursor-system: pointer;
 
     &:active {
         cursor: grabbing;

--- a/assets/buttons_cursor.css
+++ b/assets/buttons_cursor.css
@@ -3,3 +3,6 @@
 button {
     cursor: pointer;
 }
+button:active {
+    cursor: grabbing;
+}

--- a/assets/buttons_cursor.css
+++ b/assets/buttons_cursor.css
@@ -8,6 +8,6 @@ button {
     }
 }
 
-button.dark-light-button:active {
+button:not(.dark-light-button):active {
     cursor: url("panel-border-010.png");
 }

--- a/assets/buttons_cursor.css
+++ b/assets/buttons_cursor.css
@@ -2,7 +2,12 @@
 
 button {
     cursor: pointer;
+
+    &:active {
+        cursor: grabbing;
+    }
 }
-button:active {
-    cursor: grabbing;
+
+button.dark-light-button:active {
+    cursor: url("panel-border-010.png");
 }

--- a/crates/bevy_flair_core/Cargo.toml
+++ b/crates/bevy_flair_core/Cargo.toml
@@ -40,6 +40,7 @@ bevy_window = { workspace = true, optional = true }
 
 [features]
 experimental_cursor_property = ["dep:bevy_window"]
+experimental_cursor_custom = []
 
 [dev-dependencies]
 bevy_math = { workspace = true }

--- a/crates/bevy_flair_core/Cargo.toml
+++ b/crates/bevy_flair_core/Cargo.toml
@@ -36,5 +36,8 @@ bevy_math = { workspace = true }
 bevy_text = { workspace = true }
 bevy_ui = { workspace = true }
 
+[features]
+experimental_cursor_property = []
+
 [dev-dependencies]
 bevy_math = { workspace = true }

--- a/crates/bevy_flair_core/Cargo.toml
+++ b/crates/bevy_flair_core/Cargo.toml
@@ -35,6 +35,7 @@ bevy_image = { workspace = true }
 bevy_math = { workspace = true }
 bevy_text = { workspace = true }
 bevy_ui = { workspace = true }
+
 bevy_window = { workspace = true, optional = true }
 
 [features]

--- a/crates/bevy_flair_core/Cargo.toml
+++ b/crates/bevy_flair_core/Cargo.toml
@@ -35,9 +35,10 @@ bevy_image = { workspace = true }
 bevy_math = { workspace = true }
 bevy_text = { workspace = true }
 bevy_ui = { workspace = true }
+bevy_window = { workspace = true, optional = true }
 
 [features]
-experimental_cursor_property = []
+experimental_cursor_property = ["dep:bevy_window"]
 
 [dev-dependencies]
 bevy_math = { workspace = true }

--- a/crates/bevy_flair_core/src/components.rs
+++ b/crates/bevy_flair_core/src/components.rs
@@ -1,3 +1,6 @@
+//! Contains components which manage certain styling properties.
+
+
 #[cfg(feature = "experimental_cursor_property")]
 mod hover_cursor_icon;
 #[cfg(feature = "experimental_cursor_property")]

--- a/crates/bevy_flair_core/src/components.rs
+++ b/crates/bevy_flair_core/src/components.rs
@@ -1,0 +1,4 @@
+#[cfg(feature = "experimental_cursor_property")]
+mod hover_cursor_icon;
+#[cfg(feature = "experimental_cursor_property")]
+pub use hover_cursor_icon::*;

--- a/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
+++ b/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
@@ -82,9 +82,9 @@ pub struct HoverCursorIcon {
     #[cfg(feature = "experimental_cursor_custom")]
     pub custom_rect: URect,
     #[cfg(feature = "experimental_cursor_custom")]
-    pub custom_hotspot_x: u16,
+    pub custom_hotspot_x: f32,
     #[cfg(feature = "experimental_cursor_custom")]
-    pub custom_hotspot_y: u16
+    pub custom_hotspot_y: f32
 }
 
 impl Default for HoverCursorIcon {
@@ -100,9 +100,9 @@ impl Default for HoverCursorIcon {
             #[cfg(feature = "experimental_cursor_custom")]
             custom_rect: URect::EMPTY,
             #[cfg(feature = "experimental_cursor_custom")]
-            custom_hotspot_x: 0,
+            custom_hotspot_x: 0.0,
             #[cfg(feature = "experimental_cursor_custom")]
-            custom_hotspot_y: 0
+            custom_hotspot_y: 0.0
         }
     }
 }
@@ -120,7 +120,7 @@ impl From<&HoverCursorIcon> for CursorIcon {
                     flip_x        : hci.custom_flip_x,
                     flip_y        : hci.custom_flip_y,
                     rect          : (! hci.custom_rect.is_empty()).then(|| hci.custom_rect),
-                    hotspot       : (hci.custom_hotspot_x, hci.custom_hotspot_y,)
+                    hotspot       : (hci.custom_hotspot_x as u16, hci.custom_hotspot_y as u16,)
                 }))
             }
         }

--- a/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
+++ b/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
@@ -24,6 +24,15 @@ use bevy_window::{
 };
 
 
+/// Component which marks a [`Window`]'s [`CursorIcon`] as managed by a [`HoverCursorIcon`] entity.
+///
+/// *This component should not be used manually*
+#[derive(Component, Debug, Default, Clone, PartialEq, Eq, Reflect)]
+#[reflect(Component, Debug, Default, Clone, PartialEq)]
+#[component(immutable)]
+pub struct ManagedCursorIcon;
+
+
 /// Component which changes the window [`CursorIcon`] when [hovered](Interaction).
 #[derive(Component, Debug, Default, Clone, PartialEq, Eq, Reflect)]
 #[reflect(Component, Debug, Default, Clone, PartialEq)]
@@ -36,6 +45,8 @@ pub struct HoverCursorIcon {
 /// Component which tracks which window's [`CursorIcon`] this [`HoverCursorIcon`] is controlling.
 ///
 /// Used to remove the component when this entity is unhovered.
+///
+/// *This component should not be used manually*
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq, Reflect)]
 #[reflect(Component, Debug, Clone, PartialEq)]
 #[component(immutable)]
@@ -47,12 +58,17 @@ fn hovered_cursor_icon_inserted(mut world: DeferredWorld, ctx: HookContext) {
     let HoveredCursorIcon(window_entity) = *world.get::<HoveredCursorIcon>(ctx.entity).unwrap();
     let hci = world.get::<HoverCursorIcon>(ctx.entity).unwrap();
     let icon = CursorIcon::from(hci.system);
-    world.commands().entity(window_entity).insert(icon);
+    world.commands().entity(window_entity).insert((
+        ManagedCursorIcon,
+        icon,
+    ));
 }
 
 fn cursor_icon_removed(mut world: DeferredWorld, ctx: HookContext) {
     if let Some(&HoveredCursorIcon(window_entity)) = world.get::<HoveredCursorIcon>(ctx.entity) {
-        world.commands().entity(window_entity).remove::<CursorIcon>();
+        world.commands().entity(window_entity)
+            .remove::<CursorIcon>()
+            .remove::<ManagedCursorIcon>();
     }
 }
 

--- a/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
+++ b/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
@@ -17,7 +17,7 @@ use bevy_ecs::{
     world::DeferredWorld
 };
 use bevy_image::Image;
-use bevy_math::URect;
+use bevy_math::{ Rect, URect };
 use bevy_reflect::{
     Reflect,
     std_traits::ReflectDefault
@@ -80,7 +80,7 @@ pub struct HoverCursorIcon {
     #[cfg(feature = "experimental_cursor_custom")]
     pub custom_flip_y: bool,
     #[cfg(feature = "experimental_cursor_custom")]
-    pub custom_rect: URect,
+    pub custom_rect: Rect,
     #[cfg(feature = "experimental_cursor_custom")]
     pub custom_hotspot_x: f32,
     #[cfg(feature = "experimental_cursor_custom")]
@@ -98,7 +98,7 @@ impl Default for HoverCursorIcon {
             #[cfg(feature = "experimental_cursor_custom")]
             custom_flip_y: false,
             #[cfg(feature = "experimental_cursor_custom")]
-            custom_rect: URect::EMPTY,
+            custom_rect: Rect::EMPTY,
             #[cfg(feature = "experimental_cursor_custom")]
             custom_hotspot_x: 0.0,
             #[cfg(feature = "experimental_cursor_custom")]
@@ -119,7 +119,12 @@ impl From<&HoverCursorIcon> for CursorIcon {
                     texture_atlas : None,
                     flip_x        : hci.custom_flip_x,
                     flip_y        : hci.custom_flip_y,
-                    rect          : (! hci.custom_rect.is_empty()).then(|| hci.custom_rect),
+                    rect          : (! hci.custom_rect.is_empty()).then(|| URect::new(
+                        hci.custom_rect.min.x as u32,
+                        hci.custom_rect.min.y as u32,
+                        hci.custom_rect.max.x as u32,
+                        hci.custom_rect.max.y as u32,
+                    )),
                     hotspot       : (hci.custom_hotspot_x as u16, hci.custom_hotspot_y as u16,)
                 }))
             }

--- a/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
+++ b/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
@@ -64,6 +64,7 @@ fn default_cursor_icon_removed(mut world: DeferredWorld, ctx: HookContext) {
 #[derive(Component, Debug, Default, Clone, PartialEq, Eq, Reflect)]
 #[reflect(Component, Debug, Default, Clone, PartialEq)]
 #[component(immutable)]
+#[component(storage = "SparseSet")]
 pub struct ManagedCursorIcon;
 
 
@@ -179,6 +180,7 @@ impl From<&HoverCursorIcon> for CursorIcon {
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq, Reflect)]
 #[reflect(Component, Debug, Clone, PartialEq)]
 #[component(immutable)]
+#[component(storage = "SparseSet")]
 #[component(on_insert = hovered_cursor_icon_inserted)]
 #[component(on_remove = cursor_icon_removed)]
 pub struct HoveredCursorIcon(pub Entity);

--- a/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
+++ b/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
@@ -6,9 +6,11 @@ use bevy_app::{
 use bevy_ecs::{
     component::Component,
     entity::Entity,
+    lifecycle::HookContext,
     reflect::ReflectComponent,
     query::{ Changed, Or },
-    system::{ Query, Commands }
+    system::{ Query, Commands },
+    world::DeferredWorld
 };
 use bevy_reflect::{
     Reflect,
@@ -22,10 +24,36 @@ use bevy_window::{
 };
 
 
+/// Component which changes the window [`CursorIcon`] when [hovered](Interaction).
 #[derive(Component, Debug, Default, Clone, PartialEq, Eq, Reflect)]
 #[reflect(Component, Debug, Default, Clone, PartialEq)]
+#[component(on_remove = cursor_icon_removed)]
 pub struct HoverCursorIcon {
     pub system : SystemCursorIcon
+}
+
+
+/// Component which tracks which window's [`CursorIcon`] this [`HoverCursorIcon`] is controlling.
+///
+/// Used to remove the component when this entity is unhovered.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq, Reflect)]
+#[reflect(Component, Debug, Clone, PartialEq)]
+#[component(immutable)]
+#[component(on_insert = hovered_cursor_icon_inserted)]
+#[component(on_remove = cursor_icon_removed)]
+pub struct HoveredCursorIcon(pub Entity);
+
+fn hovered_cursor_icon_inserted(mut world: DeferredWorld, ctx: HookContext) {
+    let HoveredCursorIcon(window_entity) = *world.get::<HoveredCursorIcon>(ctx.entity).unwrap();
+    let hci = world.get::<HoverCursorIcon>(ctx.entity).unwrap();
+    let icon = CursorIcon::from(hci.system);
+    world.commands().entity(window_entity).insert(icon);
+}
+
+fn cursor_icon_removed(mut world: DeferredWorld, ctx: HookContext) {
+    if let Some(&HoveredCursorIcon(window_entity)) = world.get::<HoveredCursorIcon>(ctx.entity) {
+        world.commands().entity(window_entity).remove::<CursorIcon>();
+    }
 }
 
 
@@ -34,18 +62,23 @@ pub struct HoverCursorPlugin;
 
 impl Plugin for HoverCursorPlugin {
     fn build(&self, app : &mut App) {
-        app.add_systems(Update, update_cursor_icon);
+        app
+            .add_systems(Update, update_cursor_icon);
     }
 }
 
 fn update_cursor_icon(
     mut cmds: Commands,
-    cursor_icons: Query<(&HoverCursorIcon, &Interaction), (Or<(Changed<HoverCursorIcon>, Changed<Interaction>,)>,)>,
+    cursor_icons: Query<(Entity, &HoverCursorIcon, &Interaction), (Or<(Changed<HoverCursorIcon>, Changed<Interaction>,)>,)>,
     windows: Query<(Entity, &Window,),>
 ) {
-    if let Some((icon, _,)) = cursor_icons.iter().find(|(_, interaction,)| matches!(interaction, Interaction::Hovered|Interaction::Pressed)){
-        if let Some((entity, _,)) = windows.iter().find(|(_, window,)| window.focused) {
-            cmds.entity(entity).insert(CursorIcon::from(icon.system));
+    for (interacted_entity, icon, interaction,) in &cursor_icons {
+        if let Interaction::Hovered|Interaction::Pressed = interaction {
+            if let Some((window_entity, _,)) = windows.iter().find(|(_, window,)| window.focused) {
+                cmds.entity(interacted_entity).insert(HoveredCursorIcon(window_entity));
+            }
+        } else {
+            cmds.entity(interacted_entity).remove::<HoveredCursorIcon>();
         }
     }
 }

--- a/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
+++ b/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
@@ -220,10 +220,10 @@ impl Plugin for HoverCursorPlugin {
 
 fn update_cursor_icon(
     mut cmds: Commands,
-    cursor_icons: Query<(Entity, &HoverCursorIcon, &Interaction), (Or<(Changed<HoverCursorIcon>, Changed<Interaction>,)>,)>,
+    cursor_icons: Query<(Entity, &Interaction), (Or<(Changed<HoverCursorIcon>, Changed<Interaction>,)>,)>,
     windows: Query<(Entity, &Window,),>
 ) {
-    for (interacted_entity, icon, interaction,) in &cursor_icons {
+    for (interacted_entity, interaction,) in &cursor_icons {
         if let Interaction::Hovered|Interaction::Pressed = interaction {
             if let Some((window_entity, _,)) = windows.iter().find(|(_, window,)| window.focused) {
                 cmds.entity(interacted_entity).insert(HoveredCursorIcon(window_entity));

--- a/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
+++ b/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
@@ -42,7 +42,7 @@ fn default_cursor_icon_inserted(mut world: DeferredWorld, ctx: HookContext) {
 
 fn default_cursor_icon_removed(mut world: DeferredWorld, ctx: HookContext) {
     if world.get::<ManagedCursorIcon>(ctx.entity).is_none() {
-        world.commands().entity(ctx.entity).remove::<CursorIcon>();
+        world.commands().entity(ctx.entity).try_remove::<CursorIcon>();
     }
 }
 
@@ -93,11 +93,11 @@ fn cursor_icon_removed(mut world: DeferredWorld, ctx: HookContext) {
         let mut cmds = world.commands();
         let mut window = cmds.entity(window_entity);
         if let Some(dci) = icon {
-            window.insert(dci.0);
+            window.try_insert(dci.0);
         } else {
-            window.remove::<CursorIcon>();
+            window.try_remove::<CursorIcon>();
         }
-        window.remove::<ManagedCursorIcon>();
+        window.try_remove::<ManagedCursorIcon>();
     }
 }
 

--- a/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
+++ b/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
@@ -1,16 +1,51 @@
+use bevy_app::{
+    App,
+    Plugin,
+    Update
+};
 use bevy_ecs::{
     component::Component,
-    reflect::ReflectComponent
+    entity::Entity,
+    reflect::ReflectComponent,
+    query::{ Changed, Or },
+    system::{ Query, Commands }
 };
 use bevy_reflect::{
     Reflect,
     std_traits::ReflectDefault
 };
-use bevy_window::SystemCursorIcon;
+use bevy_ui::Interaction;
+use bevy_window::{
+    Window,
+    CursorIcon,
+    SystemCursorIcon
+};
 
 
 #[derive(Component, Debug, Default, Clone, PartialEq, Eq, Reflect)]
 #[reflect(Component, Debug, Default, Clone, PartialEq)]
 pub struct HoverCursorIcon {
     pub system : SystemCursorIcon
+}
+
+
+#[derive(Default)]
+pub struct HoverCursorPlugin;
+
+impl Plugin for HoverCursorPlugin {
+    fn build(&self, app : &mut App) {
+        app.add_systems(Update, update_cursor_icon);
+    }
+}
+
+fn update_cursor_icon(
+    mut cmds: Commands,
+    cursor_icons: Query<(&HoverCursorIcon, &Interaction), (Or<(Changed<HoverCursorIcon>, Changed<Interaction>,)>,)>,
+    windows: Query<(Entity, &Window,),>
+) {
+    if let Some((icon, _,)) = cursor_icons.iter().find(|(_, interaction,)| matches!(interaction, Interaction::Hovered|Interaction::Pressed)){
+        if let Some((entity, _,)) = windows.iter().find(|(_, window,)| window.focused) {
+            cmds.entity(entity).insert(CursorIcon::from(icon.system));
+        }
+    }
 }

--- a/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
+++ b/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
@@ -3,6 +3,7 @@ use bevy_app::{
     Plugin,
     Update
 };
+use bevy_asset::Handle;
 use bevy_ecs::{
     component::Component,
     entity::Entity,
@@ -12,11 +13,15 @@ use bevy_ecs::{
     system::{ Query, Commands },
     world::DeferredWorld
 };
+use bevy_image::Image;
 use bevy_reflect::{
     Reflect,
     std_traits::ReflectDefault
 };
-use bevy_ui::Interaction;
+use bevy_ui::{
+    Interaction,
+    UiRect
+};
 use bevy_window::{
     Window,
     CursorIcon,
@@ -57,11 +62,17 @@ pub struct ManagedCursorIcon;
 
 
 /// Component which changes the window [`CursorIcon`] when [hovered](Interaction).
-#[derive(Component, Debug, Default, Clone, PartialEq, Eq, Reflect)]
+#[derive(Component, Debug, Default, Clone, PartialEq, Reflect)]
 #[reflect(Component, Debug, Default, Clone, PartialEq)]
 #[component(on_remove = cursor_icon_removed)]
 pub struct HoverCursorIcon {
-    pub system : SystemCursorIcon
+    pub system: SystemCursorIcon,
+    pub custom_handle: Option<Handle<Image>>,
+    pub custom_flip_x: bool,
+    pub custom_flip_y: bool,
+    pub custom_flip_rect: Option<UiRect>,
+    pub custom_hotspot_x: u16,
+    pub custom_hotspot_y: u16
 }
 
 

--- a/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
+++ b/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
@@ -60,7 +60,7 @@ fn default_cursor_icon_removed(mut world: DeferredWorld, ctx: HookContext) {
 
 /// Component which marks a [`Window`]'s [`CursorIcon`] as managed by a [`HoverCursorIcon`] entity.
 ///
-/// *This component should not be used manually*
+/// ***This component should not be used manually***
 #[derive(Component, Debug, Default, Clone, PartialEq, Eq, Reflect)]
 #[reflect(Component, Debug, Default, Clone, PartialEq)]
 #[component(immutable)]
@@ -175,7 +175,7 @@ impl From<&HoverCursorIcon> for CursorIcon {
 ///
 /// Used to remove the component when this entity is unhovered.
 ///
-/// *This component should not be used manually*
+/// ***This component should not be used manually***
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq, Reflect)]
 #[reflect(Component, Debug, Clone, PartialEq)]
 #[component(immutable)]
@@ -208,13 +208,13 @@ fn cursor_icon_removed(mut world: DeferredWorld, ctx: HookContext) {
 }
 
 
+/// Plugin that adds hover cursor icon systems to Bevy.
 #[derive(Default)]
 pub struct HoverCursorPlugin;
 
 impl Plugin for HoverCursorPlugin {
     fn build(&self, app : &mut App) {
-        app
-            .add_systems(Update, update_cursor_icon);
+        app.add_systems(Update, update_cursor_icon);
     }
 }
 

--- a/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
+++ b/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
@@ -72,17 +72,53 @@ pub struct ManagedCursorIcon;
 #[reflect(Component, Debug, Default, Clone, PartialEq)]
 #[component(on_remove = cursor_icon_removed)]
 pub struct HoverCursorIcon {
+    /// A system-provided icon to use as the cursor.
+    ///
+    /// See [`SystemCursorIcon`].
     pub system: SystemCursorIcon,
+
+    /// Handle to the image to use as the cursor.
+    /// The image must be in 8 bit int or 32 bit float rgba.
+    /// PNG images work well for this.
+    ///
+    /// See [`CustomCursorImage::handle`].
+    ///
+    /// The system icon will be used instead if this is `Handle::Uuid(AssetId::<Image>::INVALID_UUID, _)`.
     #[cfg(feature = "experimental_cursor_custom")]
     pub custom_handle: Handle<Image>,
+
+    /// Whether the image should be flipped along its x-axis.
+    ///
+    /// See [`CustomCursorImage::flip_x`].
     #[cfg(feature = "experimental_cursor_custom")]
     pub custom_flip_x: bool,
+
+    /// Whether the image should be flipped along its y-axis.
+    ///
+    /// See [`CustomCursorImage::flip_y`].
     #[cfg(feature = "experimental_cursor_custom")]
     pub custom_flip_y: bool,
+
+    /// Whether the image should be flipped along its y-axis.
+    ///
+    /// See [`CustomCursorImage::rect`].
+    ///
+    /// The default rect will be used if this has no area.
     #[cfg(feature = "experimental_cursor_custom")]
     pub custom_rect: Rect,
+
+    /// X coordinate of the hotspot in pixels.
+    /// The hotspot must be within the image bounds.
+    ///
+    /// See [`CustomCursorImage::hotspot`].
     #[cfg(feature = "experimental_cursor_custom")]
     pub custom_hotspot_x: f32,
+
+
+    /// Y coordinate of the hotspot in pixels.
+    /// The hotspot must be within the image bounds.
+    ///
+    /// See [`CustomCursorImage::hotspot`].
     #[cfg(feature = "experimental_cursor_custom")]
     pub custom_hotspot_y: f32
 }

--- a/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
+++ b/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
@@ -1,0 +1,14 @@
+use bevy_ecs::{
+    component::Component,
+    reflect::ReflectComponent
+};
+use bevy_reflect::{
+    Reflect,
+    std_traits::ReflectDefault
+};
+use bevy_window::CursorIcon;
+
+
+#[derive(Component, Debug, Default, Clone, PartialEq, Eq, Reflect)]
+#[reflect(Component, Debug, Default, Clone, PartialEq)]
+pub struct HoverCursorIcon(pub CursorIcon);

--- a/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
+++ b/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
@@ -89,9 +89,15 @@ fn hovered_cursor_icon_inserted(mut world: DeferredWorld, ctx: HookContext) {
 
 fn cursor_icon_removed(mut world: DeferredWorld, ctx: HookContext) {
     if let Some(&HoveredCursorIcon(window_entity)) = world.get::<HoveredCursorIcon>(ctx.entity) {
-        world.commands().entity(window_entity)
-            .remove::<CursorIcon>()
-            .remove::<ManagedCursorIcon>();
+        let icon = world.get::<DefaultCursorIcon>(window_entity).cloned();
+        let mut cmds = world.commands();
+        let mut window = cmds.entity(window_entity);
+        if let Some(dci) = icon {
+            window.insert(dci.0);
+        } else {
+            window.remove::<CursorIcon>();
+        }
+        window.remove::<ManagedCursorIcon>();
     }
 }
 

--- a/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
+++ b/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
@@ -47,7 +47,7 @@ fn default_cursor_icon_inserted(mut world: DeferredWorld, ctx: HookContext) {
     if world.get::<ManagedCursorIcon>(ctx.entity).is_none() {
         let dci  = world.get::<DefaultCursorIcon>(ctx.entity).unwrap();
         let icon = dci.0.clone();
-        world.commands().entity(ctx.entity).insert((icon,));
+        world.commands().entity(ctx.entity).try_insert((icon,));
     }
 }
 
@@ -187,12 +187,17 @@ pub struct HoveredCursorIcon(pub Entity);
 
 fn hovered_cursor_icon_inserted(mut world: DeferredWorld, ctx: HookContext) {
     let HoveredCursorIcon(window_entity) = *world.get::<HoveredCursorIcon>(ctx.entity).unwrap();
-    let hci = world.get::<HoverCursorIcon>(ctx.entity).unwrap();
-    let icon = CursorIcon::from(hci);
-    world.commands().entity(window_entity).insert((
-        ManagedCursorIcon,
-        icon,
-    ));
+    if let Some(hci) = world.get::<HoverCursorIcon>(ctx.entity) {
+        let icon = CursorIcon::from(hci);
+        world.commands().entity(window_entity).try_insert((
+            ManagedCursorIcon,
+            icon,
+        ));
+    } else {
+        world.commands().entity(window_entity)
+            .try_remove::<CursorIcon>()
+            .try_remove::<ManagedCursorIcon>();
+    }
 }
 
 fn cursor_icon_removed(mut world: DeferredWorld, ctx: HookContext) {

--- a/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
+++ b/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
@@ -6,9 +6,11 @@ use bevy_reflect::{
     Reflect,
     std_traits::ReflectDefault
 };
-use bevy_window::CursorIcon;
+use bevy_window::SystemCursorIcon;
 
 
 #[derive(Component, Debug, Default, Clone, PartialEq, Eq, Reflect)]
 #[reflect(Component, Debug, Default, Clone, PartialEq)]
-pub struct HoverCursorIcon(pub CursorIcon);
+pub struct HoverCursorIcon {
+    pub system : SystemCursorIcon
+}

--- a/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
+++ b/crates/bevy_flair_core/src/components/hover_cursor_icon.rs
@@ -24,6 +24,29 @@ use bevy_window::{
 };
 
 
+/// Component that can be added to a [`Window`], which sets the [`CursorIcon`]
+///  to some default when a [`HoverCursorIcon`] is un[hovered](Interaction).
+#[derive(Component, Debug, Default, Clone, PartialEq, Eq, Reflect)]
+#[reflect(Component, Debug, Default, Clone, PartialEq)]
+#[component(on_insert = default_cursor_icon_inserted)]
+#[component(on_remove = default_cursor_icon_removed)]
+pub struct DefaultCursorIcon(pub CursorIcon);
+
+fn default_cursor_icon_inserted(mut world: DeferredWorld, ctx: HookContext) {
+    if world.get::<ManagedCursorIcon>(ctx.entity).is_none() {
+        let dci  = world.get::<DefaultCursorIcon>(ctx.entity).unwrap();
+        let icon = dci.0.clone();
+        world.commands().entity(ctx.entity).insert((icon,));
+    }
+}
+
+fn default_cursor_icon_removed(mut world: DeferredWorld, ctx: HookContext) {
+    if world.get::<ManagedCursorIcon>(ctx.entity).is_none() {
+        world.commands().entity(ctx.entity).remove::<CursorIcon>();
+    }
+}
+
+
 /// Component which marks a [`Window`]'s [`CursorIcon`] as managed by a [`HoverCursorIcon`] entity.
 ///
 /// *This component should not be used manually*

--- a/crates/bevy_flair_core/src/impls.rs
+++ b/crates/bevy_flair_core/src/impls.rs
@@ -16,8 +16,6 @@ use crate::components::HoverCursorIcon;
 use bevy_window::SystemCursorIcon;
 #[cfg(feature = "experimental_cursor_custom")]
 use bevy_image::Image;
-#[cfg(feature = "experimental_cursor_custom")]
-use bevy_math::URect;
 
 impl_extract_component_properties! {
     pub struct UiRect {
@@ -208,7 +206,7 @@ impl_component_properties! {
         pub custom_handle: Handle<Image>,
         pub custom_flip_x: bool,
         pub custom_flip_y: bool,
-        pub custom_rect: URect,
+        pub custom_rect: Rect,
         pub custom_hotspot_x: f32,
         pub custom_hotspot_y: f32,
     }

--- a/crates/bevy_flair_core/src/impls.rs
+++ b/crates/bevy_flair_core/src/impls.rs
@@ -189,6 +189,7 @@ impl_component_properties! {
 
 #[cfg(feature = "experimental_cursor_property")]
 impl_component_properties! {
+    #[component(auto_insert_remove)]
     pub struct HoverCursorIcon {
         pub system: SystemCursorIcon,
     }

--- a/crates/bevy_flair_core/src/impls.rs
+++ b/crates/bevy_flair_core/src/impls.rs
@@ -13,9 +13,11 @@ use bevy_ui::prelude::*;
 #[cfg(feature = "experimental_cursor_property")]
 use crate::components::HoverCursorIcon;
 #[cfg(feature = "experimental_cursor_property")]
-use bevy_image::Image;
-#[cfg(feature = "experimental_cursor_property")]
 use bevy_window::SystemCursorIcon;
+#[cfg(feature = "experimental_cursor_custom")]
+use bevy_image::Image;
+#[cfg(feature = "experimental_cursor_custom")]
+use bevy_math::URect;
 
 impl_extract_component_properties! {
     pub struct UiRect {
@@ -190,6 +192,7 @@ impl_component_properties! {
 }
 
 #[cfg(feature = "experimental_cursor_property")]
+#[cfg(feature = "experimental_cursor_custom")]
 impl_component_properties! {
     #[component(auto_insert_remove)]
     pub struct HoverCursorIcon {
@@ -197,9 +200,17 @@ impl_component_properties! {
         pub custom_handle: Handle<Image>,
         pub custom_flip_x: bool,
         pub custom_flip_y: bool,
-        pub custom_flip_rect: UiRect,
+        pub custom_rect: URect,
         pub custom_hotspot_x: u16,
         pub custom_hotspot_y: u16,
+    }
+}
+#[cfg(feature = "experimental_cursor_property")]
+#[cfg(not(feature = "experimental_cursor_custom"))]
+impl_component_properties! {
+    #[component(auto_insert_remove)]
+    pub struct HoverCursorIcon {
+        pub system: SystemCursorIcon,
     }
 }
 
@@ -384,6 +395,9 @@ impl Plugin for ImplComponentPropertiesPlugin {
         #[cfg(feature = "experimental_cursor_property")]
         set_css_properties!(app => {
             "-bevy-cursor-system" => HoverCursorIcon[".system"],
+        });
+        #[cfg(feature = "experimental_cursor_custom")]
+        set_css_properties!(app => {
             "-bevy-cursor-image" => HoverCursorIcon[".custom_handle"],
             "-bevy-cursor-image-flip-x" => HoverCursorIcon[".custom_flip_x"],
             "-bevy-cursor-image-flip-y" => HoverCursorIcon[".custom_flip_y"],

--- a/crates/bevy_flair_core/src/impls.rs
+++ b/crates/bevy_flair_core/src/impls.rs
@@ -10,6 +10,11 @@ use bevy_text::prelude::*;
 use bevy_text::{FontSmoothing, LineHeight};
 use bevy_ui::prelude::*;
 
+#[cfg(feature = "experimental_cursor_property")]
+use crate::components::HoverCursorIcon;
+#[cfg(feature = "experimental_cursor_property")]
+use bevy_window::SystemCursorIcon;
+
 impl_extract_component_properties! {
     pub struct UiRect {
         pub left: Val,
@@ -182,6 +187,13 @@ impl_component_properties! {
     pub struct TextShadow
 }
 
+#[cfg(feature = "experimental_cursor_property")]
+impl_component_properties! {
+    pub struct HoverCursorIcon {
+        pub system: SystemCursorIcon,
+    }
+}
+
 macro_rules! register_component_properties {
     ($app:expr => { $($ty:path,)* }) => {
         $(
@@ -244,8 +256,12 @@ impl Plugin for ImplComponentPropertiesPlugin {
             TextShadow,
             TextSpan,
         });
+        #[cfg(feature = "experimental_cursor_property")]
+        register_component_properties!(app => { HoverCursorIcon, });
 
         set_inherited_properties!(app => { TextColor, TextFont, TextLayout, });
+        #[cfg(feature = "experimental_cursor_property")]
+        set_inherited_properties!(app => { HoverCursorIcon, });
 
         set_css_properties!(app => {
             "display" => Node[".display"],
@@ -355,6 +371,10 @@ impl Plugin for ImplComponentPropertiesPlugin {
 
             // Misc text components
             "text-shadow" => TextShadow[""],
+        });
+        #[cfg(feature = "experimental_cursor_property")]
+        set_css_properties!(app => {
+            "-bevy-cursor-system" => HoverCursorIcon[".system"],
         });
     }
 }

--- a/crates/bevy_flair_core/src/impls.rs
+++ b/crates/bevy_flair_core/src/impls.rs
@@ -13,6 +13,8 @@ use bevy_ui::prelude::*;
 #[cfg(feature = "experimental_cursor_property")]
 use crate::components::HoverCursorIcon;
 #[cfg(feature = "experimental_cursor_property")]
+use bevy_image::Image;
+#[cfg(feature = "experimental_cursor_property")]
 use bevy_window::SystemCursorIcon;
 
 impl_extract_component_properties! {
@@ -192,6 +194,12 @@ impl_component_properties! {
     #[component(auto_insert_remove)]
     pub struct HoverCursorIcon {
         pub system: SystemCursorIcon,
+        pub custom_handle: Handle<Image>,
+        pub custom_flip_x: bool,
+        pub custom_flip_y: bool,
+        pub custom_flip_rect: UiRect,
+        pub custom_hotspot_x: u16,
+        pub custom_hotspot_y: u16,
     }
 }
 
@@ -376,6 +384,12 @@ impl Plugin for ImplComponentPropertiesPlugin {
         #[cfg(feature = "experimental_cursor_property")]
         set_css_properties!(app => {
             "-bevy-cursor-system" => HoverCursorIcon[".system"],
+            "-bevy-cursor-image" => HoverCursorIcon[".custom_handle"],
+            "-bevy-cursor-image-flip-x" => HoverCursorIcon[".custom_flip_x"],
+            "-bevy-cursor-image-flip-y" => HoverCursorIcon[".custom_flip_y"],
+            "-bevy-cursor-image-rect" => HoverCursorIcon[".custom_rect"],
+            "-bevy-cursor-image-hotspot-x" => HoverCursorIcon[".custom_hotspot_x"],
+            "-bevy-cursor-image-hotspot-y" => HoverCursorIcon[".custom_hotspot_y"],
         });
     }
 }

--- a/crates/bevy_flair_core/src/impls.rs
+++ b/crates/bevy_flair_core/src/impls.rs
@@ -192,6 +192,14 @@ impl_component_properties! {
 }
 
 #[cfg(feature = "experimental_cursor_property")]
+#[cfg(not(feature = "experimental_cursor_custom"))]
+impl_component_properties! {
+    #[component(auto_insert_remove)]
+    pub struct HoverCursorIcon {
+        pub system: SystemCursorIcon,
+    }
+}
+#[cfg(feature = "experimental_cursor_property")]
 #[cfg(feature = "experimental_cursor_custom")]
 impl_component_properties! {
     #[component(auto_insert_remove)]
@@ -201,16 +209,8 @@ impl_component_properties! {
         pub custom_flip_x: bool,
         pub custom_flip_y: bool,
         pub custom_rect: URect,
-        pub custom_hotspot_x: u16,
-        pub custom_hotspot_y: u16,
-    }
-}
-#[cfg(feature = "experimental_cursor_property")]
-#[cfg(not(feature = "experimental_cursor_custom"))]
-impl_component_properties! {
-    #[component(auto_insert_remove)]
-    pub struct HoverCursorIcon {
-        pub system: SystemCursorIcon,
+        pub custom_hotspot_x: f32,
+        pub custom_hotspot_y: f32,
     }
 }
 

--- a/crates/bevy_flair_core/src/lib.rs
+++ b/crates/bevy_flair_core/src/lib.rs
@@ -1,5 +1,6 @@
 //! # Bevy Flair Core
 
+pub mod components;
 mod component_property;
 pub mod property_map;
 mod property_value;

--- a/crates/bevy_flair_css_parser/Cargo.toml
+++ b/crates/bevy_flair_css_parser/Cargo.toml
@@ -51,6 +51,7 @@ ariadne = "0.5"
 
 [features]
 experimental_cursor_property = ["dep:bevy_window"]
+experimental_cursor_custom = []
 
 [dev-dependencies]
 indoc = "2.0"

--- a/crates/bevy_flair_css_parser/Cargo.toml
+++ b/crates/bevy_flair_css_parser/Cargo.toml
@@ -48,6 +48,9 @@ selectors = { workspace = true }
 
 ariadne = "0.5"
 
+[features]
+experimental_cursor_property = []
+
 [dev-dependencies]
 indoc = "2.0"
 approx = "0.5"

--- a/crates/bevy_flair_css_parser/Cargo.toml
+++ b/crates/bevy_flair_css_parser/Cargo.toml
@@ -38,6 +38,7 @@ bevy_math = { workspace = true }
 bevy_reflect = { workspace = true }
 bevy_text = { workspace = true }
 bevy_ui = { workspace = true }
+bevy_window = { workspace = true, optional = true }
 
 bevy_flair_core = { workspace = true }
 bevy_flair_style = { workspace = true }
@@ -49,7 +50,7 @@ selectors = { workspace = true }
 ariadne = "0.5"
 
 [features]
-experimental_cursor_property = []
+experimental_cursor_property = ["dep:bevy_window"]
 
 [dev-dependencies]
 indoc = "2.0"

--- a/crates/bevy_flair_css_parser/src/error_codes.rs
+++ b/crates/bevy_flair_css_parser/src/error_codes.rs
@@ -98,3 +98,8 @@ define_errors!(animations => {
     INVALID_ANIMATION_NAME(123, "Invalid animation name"),
     INVALID_TRANSITION_PROPERTY_NAME(124, "Invalid transition property name"),
 });
+
+#[cfg(feature = "experimental_cursor_property")]
+define_errors!(cursor => {
+    INVALID_SYSTEM_CURSOR(120, "Invalid system cursor"),
+});

--- a/crates/bevy_flair_css_parser/src/error_codes.rs
+++ b/crates/bevy_flair_css_parser/src/error_codes.rs
@@ -101,5 +101,5 @@ define_errors!(animations => {
 
 #[cfg(feature = "experimental_cursor_property")]
 define_errors!(cursor => {
-    INVALID_SYSTEM_CURSOR(120, "Invalid system cursor"),
+    INVALID_CURSOR(120, "Invalid cursor type"),
 });

--- a/crates/bevy_flair_css_parser/src/reflect.rs
+++ b/crates/bevy_flair_css_parser/src/reflect.rs
@@ -24,6 +24,9 @@ use bevy_math::{Rect, Rot2, Vec2};
 use bevy_text::{FontSmoothing, Justify, LineBreak, LineHeight};
 use bevy_ui::widget::NodeImageMode;
 
+#[cfg(feature = "experimental_cursor_custom")]
+use bevy_window::SystemCursorIcon;
+
 /// A function that parses a CSS type.
 /// When the function succeeds, it should return a [`bevy_flair_core::ReflectValue`].
 /// When the function fails, it should return a [`CssError`].
@@ -156,6 +159,12 @@ impl Plugin for ReflectParsePlugin {
                 Justify,
                 LineBreak,
             )
+        );
+        #[cfg(feature = "experimental_cursor_custom")]
+        register_type_data!(
+            app,
+            ReflectParseCssEnum,
+            (SystemCursorIcon,)
         );
     }
 }

--- a/crates/bevy_flair_css_parser/src/reflect.rs
+++ b/crates/bevy_flair_css_parser/src/reflect.rs
@@ -108,6 +108,7 @@ impl Plugin for ReflectParsePlugin {
             app,
             ReflectParseCss,
             (
+                bool,
                 f32,
                 Vec2,
                 String,

--- a/crates/bevy_flair_css_parser/src/reflect/ui.rs
+++ b/crates/bevy_flair_css_parser/src/reflect/ui.rs
@@ -401,6 +401,12 @@ mod tests {
     use bevy_ui::{BoxShadow, OverflowClipBox, OverflowClipMargin, ShadowStyle, Val, Val2, ZIndex};
 
     #[test]
+    fn test_bool() {
+        assert!(test_parse_reflect::<bool>("true"));
+        assert!(! test_parse_reflect::<bool>("false"));
+    }
+
+    #[test]
     fn test_f32() {
         assert_eq!(test_parse_reflect::<f32>("3"), 3.0);
         assert_eq!(test_parse_reflect::<f32>("1.5"), 1.5);

--- a/crates/bevy_flair_css_parser/src/shorthand.rs
+++ b/crates/bevy_flair_css_parser/src/shorthand.rs
@@ -1068,6 +1068,8 @@ fn parse_cursor(parser: &mut Parser) -> ShorthandParseResult {
         #[cfg(feature = "experimental_cursor_custom")]
         result.push((BEVY_CURSOR_IMAGE_FLIP_Y, PropertyValue::Initial));
         #[cfg(feature = "experimental_cursor_custom")]
+        result.push((BEVY_CURSOR_IMAGE_RECT, PropertyValue::Initial));
+        #[cfg(feature = "experimental_cursor_custom")]
         result.push((BEVY_CURSOR_IMAGE_HOTSPOT_X, PropertyValue::Initial));
         #[cfg(feature = "experimental_cursor_custom")]
         result.push((BEVY_CURSOR_IMAGE_HOTSPOT_Y, PropertyValue::Initial));

--- a/crates/bevy_flair_css_parser/src/shorthand.rs
+++ b/crates/bevy_flair_css_parser/src/shorthand.rs
@@ -1321,6 +1321,10 @@ mod tests {
         BackgroundGradient,
         AssetPathPlaceholder<Image>
     );
+    #[cfg(feature = "experimental_cursor_property")]
+    impl_into_reflect_value!(
+        SystemCursorIcon
+    );
 
     trait IntoPropertyValue {
         fn into_property_value(self) -> PropertyValue;
@@ -1766,5 +1770,57 @@ mod tests {
 ---'
 "
         );
+    }
+
+    #[cfg(feature = "experimental_cursor_property")]
+    #[cfg(not(feature = "experimental_cursor_custom"))]
+    #[test]
+    fn test_cursor_property() {
+        use bevy_window::SystemCursorIcon;
+
+        test_shorthand_property!("cursor", "pointer", {
+            "-bevy-cursor-system" => SystemCursorIcon::Pointer,
+        });
+
+        test_shorthand_property!("cursor", "nw-resize", {
+            "-bevy-cursor-system" => SystemCursorIcon::NwResize,
+        });
+    }
+
+    #[cfg(feature = "experimental_cursor_property")]
+    #[cfg(feature = "experimental_cursor_custom")]
+    #[test]
+    fn test_cursor_custom() {
+        use bevy_window::SystemCursorIcon;
+
+        test_shorthand_property!("cursor", "pointer", {
+            "-bevy-cursor-system" => SystemCursorIcon::Pointer,
+            "-bevy-cursor-image" => PropertyValue::Initial,
+            "-bevy-cursor-image-flip-x" => PropertyValue::Initial,
+            "-bevy-cursor-image-flip-y" => PropertyValue::Initial,
+            "-bevy-cursor-image-rect" => PropertyValue::Initial,
+            "-bevy-cursor-image-hotspot-x" => PropertyValue::Initial,
+            "-bevy-cursor-image-hotspot-y" => PropertyValue::Initial,
+        });
+
+        test_shorthand_property!("cursor", "nw-resize", {
+            "-bevy-cursor-system" => SystemCursorIcon::NwResize,
+            "-bevy-cursor-image" => PropertyValue::Initial,
+            "-bevy-cursor-image-flip-x" => PropertyValue::Initial,
+            "-bevy-cursor-image-flip-y" => PropertyValue::Initial,
+            "-bevy-cursor-image-rect" => PropertyValue::Initial,
+            "-bevy-cursor-image-hotspot-x" => PropertyValue::Initial,
+            "-bevy-cursor-image-hotspot-y" => PropertyValue::Initial,
+        });
+
+        test_shorthand_property!("cursor", "url('image.png')", {
+            "-bevy-cursor-system" => PropertyValue::Initial,
+            "-bevy-cursor-image" => AssetPathPlaceholder::<Image>::new("image.png"),
+            "-bevy-cursor-image-flip-x" => PropertyValue::Initial,
+            "-bevy-cursor-image-flip-y" => PropertyValue::Initial,
+            "-bevy-cursor-image-rect" => PropertyValue::Initial,
+            "-bevy-cursor-image-hotspot-x" => PropertyValue::Initial,
+            "-bevy-cursor-image-hotspot-y" => PropertyValue::Initial,
+        });
     }
 }

--- a/crates/bevy_flair_css_parser/src/shorthand.rs
+++ b/crates/bevy_flair_css_parser/src/shorthand.rs
@@ -1048,49 +1048,54 @@ fn parse_cursor_system(parser : &mut Parser) -> Result<SystemCursorIcon, CssErro
         _ => { return Err(CssError::new_located(
             &next,
             error_codes::cursor::INVALID_SYSTEM_CURSOR,
-            format!("System cursor type '{ident}' is not supported. Valid system cursor types are 'inherit' | 'default'")
+            format!("System cursor type '{ident}' is not supported. Valid system cursor types are 'inherit' | 'default' | 'context-menu' | 'help' | 'pointer' | 'progress' | 'wait' | 'cell' | 'crosshair' | 'text' | 'vertical-text' | 'alias' | 'copy' | 'move' | 'no-drop' | 'not-allowed' | 'grab' | 'grabbing' | 'e-resize' | 'n-resize' | 'ne-resize' | 'nw-resize' | 's-resize' | 'se-resize' | 'sw-resize' | 'w-resize' | 'ew-resize' | 'ns-resize' | 'nesw-resize' | 'nwse-resize' | 'col-resize' | 'row-resize' | 'all-scroll' | 'zoom-in' | 'zoom-out'")
         )); }
     })
 }
 
 #[cfg(feature = "experimental_cursor_property")]
 fn parse_cursor(parser: &mut Parser) -> ShorthandParseResult {
-    let mut result = Vec::new();
 
     if let Ok(cursor_system) =
         parser.try_parse_with(|parser| parse_property_value_with(parser, parse_cursor_system))
     {
-        result.push((BEVY_CURSOR_SYSTEM, cursor_system.map(ReflectValue::new)));
-        #[cfg(feature = "experimental_cursor_custom")]
-        result.push((BEVY_CURSOR_IMAGE, PropertyValue::Initial));
-        #[cfg(feature = "experimental_cursor_custom")]
-        result.push((BEVY_CURSOR_IMAGE_FLIP_X, PropertyValue::Initial));
-        #[cfg(feature = "experimental_cursor_custom")]
-        result.push((BEVY_CURSOR_IMAGE_FLIP_Y, PropertyValue::Initial));
-        #[cfg(feature = "experimental_cursor_custom")]
-        result.push((BEVY_CURSOR_IMAGE_RECT, PropertyValue::Initial));
-        #[cfg(feature = "experimental_cursor_custom")]
-        result.push((BEVY_CURSOR_IMAGE_HOTSPOT_X, PropertyValue::Initial));
-        #[cfg(feature = "experimental_cursor_custom")]
-        result.push((BEVY_CURSOR_IMAGE_HOTSPOT_Y, PropertyValue::Initial));
+        return Ok(vec![
+            (BEVY_CURSOR_SYSTEM, cursor_system.map(ReflectValue::new)),
+            #[cfg(feature = "experimental_cursor_custom")]
+            ((BEVY_CURSOR_IMAGE, PropertyValue::Initial)),
+            #[cfg(feature = "experimental_cursor_custom")]
+            ((BEVY_CURSOR_IMAGE_FLIP_X, PropertyValue::Initial)),
+            #[cfg(feature = "experimental_cursor_custom")]
+            ((BEVY_CURSOR_IMAGE_FLIP_Y, PropertyValue::Initial)),
+            #[cfg(feature = "experimental_cursor_custom")]
+            ((BEVY_CURSOR_IMAGE_RECT, PropertyValue::Initial)),
+            #[cfg(feature = "experimental_cursor_custom")]
+            ((BEVY_CURSOR_IMAGE_HOTSPOT_X, PropertyValue::Initial)),
+            #[cfg(feature = "experimental_cursor_custom")]
+            ((BEVY_CURSOR_IMAGE_HOTSPOT_Y, PropertyValue::Initial)),
+        ]);
     }
 
-    else {
-        #[cfg(feature = "experimental_cursor_custom")]
-        { if let Ok(cursor_image) =
-            parser.try_parse_with(|parser| parse_property_value_with(parser, parse_asset_path::<Image>))
-        {
-            result.push((BEVY_CURSOR_SYSTEM, PropertyValue::Initial));
-            result.push((BEVY_CURSOR_IMAGE, cursor_image));
-            result.push((BEVY_CURSOR_IMAGE_FLIP_X, PropertyValue::Initial));
-            result.push((BEVY_CURSOR_IMAGE_FLIP_Y, PropertyValue::Initial));
-            result.push((BEVY_CURSOR_IMAGE_RECT, PropertyValue::Initial));
-            result.push((BEVY_CURSOR_IMAGE_HOTSPOT_X, PropertyValue::Initial));
-            result.push((BEVY_CURSOR_IMAGE_HOTSPOT_Y, PropertyValue::Initial));
-        } }
+    #[cfg(feature = "experimental_cursor_custom")]
+    if let Ok(cursor_image) =
+        parser.try_parse_with(|parser| parse_property_value_with(parser, parse_asset_path::<Image>))
+    {
+        return Ok(vec![
+            (BEVY_CURSOR_SYSTEM, PropertyValue::Initial),
+            (BEVY_CURSOR_IMAGE, cursor_image),
+            (BEVY_CURSOR_IMAGE_FLIP_X, PropertyValue::Initial),
+            (BEVY_CURSOR_IMAGE_FLIP_Y, PropertyValue::Initial),
+            (BEVY_CURSOR_IMAGE_RECT, PropertyValue::Initial),
+            (BEVY_CURSOR_IMAGE_HOTSPOT_X, PropertyValue::Initial),
+            (BEVY_CURSOR_IMAGE_HOTSPOT_Y, PropertyValue::Initial),
+        ]);
     }
 
-    Ok(result)
+    Err(CssError::new_located(
+        &parser.located_next()?,
+        error_codes::cursor::INVALID_SYSTEM_CURSOR,
+        format!("Invalid cursor type. Valid cursor types are 'inherit' | 'default' | 'context-menu' | 'help' | 'pointer' | 'progress' | 'wait' | 'cell' | 'crosshair' | 'text' | 'vertical-text' | 'alias' | 'copy' | 'move' | 'no-drop' | 'not-allowed' | 'grab' | 'grabbing' | 'e-resize' | 'n-resize' | 'ne-resize' | 'nw-resize' | 's-resize' | 'se-resize' | 'sw-resize' | 'w-resize' | 'ew-resize' | 'ns-resize' | 'nesw-resize' | 'nwse-resize' | 'col-resize' | 'row-resize' | 'all-scroll' | 'zoom-in' | 'zoom-out' | 'url(\"...\")'")
+    ))
 }
 
 pub(crate) fn register_default_shorthand_properties(registry: &mut ShorthandPropertyRegistry) {

--- a/crates/bevy_flair_css_parser/src/shorthand.rs
+++ b/crates/bevy_flair_css_parser/src/shorthand.rs
@@ -1063,6 +1063,14 @@ fn parse_cursor(parser: &mut Parser) -> ShorthandParseResult {
         result.push((BEVY_CURSOR_SYSTEM, cursor_system.map(ReflectValue::new)));
         #[cfg(feature = "experimental_cursor_custom")]
         result.push((BEVY_CURSOR_IMAGE, PropertyValue::Initial));
+        #[cfg(feature = "experimental_cursor_custom")]
+        result.push((BEVY_CURSOR_IMAGE_FLIP_X, PropertyValue::Initial));
+        #[cfg(feature = "experimental_cursor_custom")]
+        result.push((BEVY_CURSOR_IMAGE_FLIP_Y, PropertyValue::Initial));
+        #[cfg(feature = "experimental_cursor_custom")]
+        result.push((BEVY_CURSOR_IMAGE_HOTSPOT_X, PropertyValue::Initial));
+        #[cfg(feature = "experimental_cursor_custom")]
+        result.push((BEVY_CURSOR_IMAGE_HOTSPOT_Y, PropertyValue::Initial));
     }
 
     else {
@@ -1071,7 +1079,12 @@ fn parse_cursor(parser: &mut Parser) -> ShorthandParseResult {
             parser.try_parse_with(|parser| parse_property_value_with(parser, parse_asset_path::<Image>))
         {
             result.push((BEVY_CURSOR_SYSTEM, PropertyValue::Initial));
-            result.push((BEVY_CURSOR_IMAGE, cursor_image))
+            result.push((BEVY_CURSOR_IMAGE, cursor_image));
+            result.push((BEVY_CURSOR_IMAGE_FLIP_X, PropertyValue::Initial));
+            result.push((BEVY_CURSOR_IMAGE_FLIP_Y, PropertyValue::Initial));
+            result.push((BEVY_CURSOR_IMAGE_RECT, PropertyValue::Initial));
+            result.push((BEVY_CURSOR_IMAGE_HOTSPOT_X, PropertyValue::Initial));
+            result.push((BEVY_CURSOR_IMAGE_HOTSPOT_Y, PropertyValue::Initial));
         } }
     }
 

--- a/crates/bevy_flair_css_parser/src/shorthand.rs
+++ b/crates/bevy_flair_css_parser/src/shorthand.rs
@@ -1190,15 +1190,19 @@ pub(crate) fn register_default_shorthand_properties(registry: &mut ShorthandProp
     );
     registry.register_new("transform", [TRANSLATE, SCALE, ROTATE], parse_transform);
     #[cfg(feature = "experimental_cursor_property")]
-    registry.register_new("cursor", [
-        BEVY_CURSOR_SYSTEM,
-        BEVY_CURSOR_IMAGE,
-        BEVY_CURSOR_IMAGE_FLIP_X,
-        BEVY_CURSOR_IMAGE_FLIP_Y,
-        BEVY_CURSOR_IMAGE_RECT,
-        BEVY_CURSOR_IMAGE_HOTSPOT_X,
-        BEVY_CURSOR_IMAGE_HOTSPOT_Y,
-    ], parse_cursor);
+    {
+        #[cfg(not(feature = "experimental_cursor_custom"))]
+        registry.register_new("cursor", [BEVY_CURSOR_SYSTEM], parse_cursor);
+        #[cfg(feature = "experimental_cursor_custom")]
+        registry.register_new("cursor", [
+            BEVY_CURSOR_IMAGE,
+            BEVY_CURSOR_IMAGE_FLIP_X,
+            BEVY_CURSOR_IMAGE_FLIP_Y,
+            BEVY_CURSOR_IMAGE_RECT,
+            BEVY_CURSOR_IMAGE_HOTSPOT_X,
+            BEVY_CURSOR_IMAGE_HOTSPOT_Y,
+        ], parse_cursor);
+    }
 }
 
 /// A plugin that registers common CSS shorthand properties.

--- a/crates/bevy_flair_css_parser/src/shorthand.rs
+++ b/crates/bevy_flair_css_parser/src/shorthand.rs
@@ -1047,7 +1047,7 @@ fn parse_cursor_system(parser : &mut Parser) -> Result<SystemCursorIcon, CssErro
 
         _ => { return Err(CssError::new_located(
             &next,
-            error_codes::cursor::INVALID_SYSTEM_CURSOR,
+            error_codes::cursor::INVALID_CURSOR,
             format!("System cursor type '{ident}' is not supported. Valid system cursor types are 'inherit' | 'default' | 'context-menu' | 'help' | 'pointer' | 'progress' | 'wait' | 'cell' | 'crosshair' | 'text' | 'vertical-text' | 'alias' | 'copy' | 'move' | 'no-drop' | 'not-allowed' | 'grab' | 'grabbing' | 'e-resize' | 'n-resize' | 'ne-resize' | 'nw-resize' | 's-resize' | 'se-resize' | 'sw-resize' | 'w-resize' | 'ew-resize' | 'ns-resize' | 'nesw-resize' | 'nwse-resize' | 'col-resize' | 'row-resize' | 'all-scroll' | 'zoom-in' | 'zoom-out'")
         )); }
     })
@@ -1093,7 +1093,7 @@ fn parse_cursor(parser: &mut Parser) -> ShorthandParseResult {
 
     Err(CssError::new_located(
         &parser.located_next()?,
-        error_codes::cursor::INVALID_SYSTEM_CURSOR,
+        error_codes::cursor::INVALID_CURSOR,
         format!("Invalid cursor type. Valid cursor types are 'inherit' | 'default' | 'context-menu' | 'help' | 'pointer' | 'progress' | 'wait' | 'cell' | 'crosshair' | 'text' | 'vertical-text' | 'alias' | 'copy' | 'move' | 'no-drop' | 'not-allowed' | 'grab' | 'grabbing' | 'e-resize' | 'n-resize' | 'ne-resize' | 'nw-resize' | 's-resize' | 'se-resize' | 'sw-resize' | 'w-resize' | 'ew-resize' | 'ns-resize' | 'nesw-resize' | 'nwse-resize' | 'col-resize' | 'row-resize' | 'all-scroll' | 'zoom-in' | 'zoom-out' | 'url(\"...\")'")
     ))
 }

--- a/crates/bevy_flair_css_parser/src/shorthand.rs
+++ b/crates/bevy_flair_css_parser/src/shorthand.rs
@@ -990,6 +990,8 @@ fn parse_transform(parser: &mut Parser) -> ShorthandParseResult {
 #[cfg(feature = "experimental_cursor_property")]
 define_css_properties! {
     const BEVY_CURSOR_SYSTEM = "-bevy-cursor-system";
+}#[cfg(feature = "experimental_cursor_custom")]
+define_css_properties! {
     const BEVY_CURSOR_IMAGE = "-bevy-cursor-image";
     const BEVY_CURSOR_IMAGE_FLIP_X = "-bevy-cursor-image-flip-x";
     const BEVY_CURSOR_IMAGE_FLIP_Y = "-bevy-cursor-image-flip-y";
@@ -1059,12 +1061,18 @@ fn parse_cursor(parser: &mut Parser) -> ShorthandParseResult {
         parser.try_parse_with(|parser| parse_property_value_with(parser, parse_cursor_system))
     {
         result.push((BEVY_CURSOR_SYSTEM, cursor_system.map(ReflectValue::new)));
+        #[cfg(feature = "experimental_cursor_custom")]
+        result.push((BEVY_CURSOR_IMAGE, PropertyValue::Initial));
     }
 
-    else if let Ok(cursor_image) =
-        parser.try_parse_with(|parser| parse_property_value_with(parser, parse_asset_path::<Image>))
-    {
-        result.push((BEVY_CURSOR_IMAGE, cursor_image))
+    else {
+        #[cfg(feature = "experimental_cursor_custom")]
+        { if let Ok(cursor_image) =
+            parser.try_parse_with(|parser| parse_property_value_with(parser, parse_asset_path::<Image>))
+        {
+            result.push((BEVY_CURSOR_SYSTEM, PropertyValue::Initial));
+            result.push((BEVY_CURSOR_IMAGE, cursor_image))
+        } }
     }
 
     Ok(result)

--- a/crates/bevy_flair_css_parser/src/shorthand.rs
+++ b/crates/bevy_flair_css_parser/src/shorthand.rs
@@ -990,7 +990,12 @@ fn parse_transform(parser: &mut Parser) -> ShorthandParseResult {
 #[cfg(feature = "experimental_cursor_property")]
 define_css_properties! {
     const BEVY_CURSOR_SYSTEM = "-bevy-cursor-system";
-    // const BEVY_CURSOR_IMAGE = "-bevy-cursor-image";
+    const BEVY_CURSOR_IMAGE = "-bevy-cursor-image";
+    const BEVY_CURSOR_IMAGE_FLIP_X = "-bevy-cursor-image-flip-x";
+    const BEVY_CURSOR_IMAGE_FLIP_Y = "-bevy-cursor-image-flip-y";
+    const BEVY_CURSOR_IMAGE_RECT = "-bevy-cursor-image-rect";
+    const BEVY_CURSOR_IMAGE_HOTSPOT_X = "-bevy-cursor-image-hotspot-x";
+    const BEVY_CURSOR_IMAGE_HOTSPOT_Y = "-bevy-cursor-image-hotspot-y";
 }
 
 #[cfg(feature = "experimental_cursor_property")]
@@ -1049,10 +1054,17 @@ fn parse_cursor_system(parser : &mut Parser) -> Result<SystemCursorIcon, CssErro
 #[cfg(feature = "experimental_cursor_property")]
 fn parse_cursor(parser: &mut Parser) -> ShorthandParseResult {
     let mut result = Vec::new();
+
     if let Ok(cursor_system) =
         parser.try_parse_with(|parser| parse_property_value_with(parser, parse_cursor_system))
     {
         result.push((BEVY_CURSOR_SYSTEM, cursor_system.map(ReflectValue::new)));
+    }
+
+    else if let Ok(cursor_image) =
+        parser.try_parse_with(|parser| parse_property_value_with(parser, parse_asset_path::<Image>))
+    {
+        result.push((BEVY_CURSOR_IMAGE, cursor_image))
     }
 
     Ok(result)
@@ -1172,7 +1184,12 @@ pub(crate) fn register_default_shorthand_properties(registry: &mut ShorthandProp
     #[cfg(feature = "experimental_cursor_property")]
     registry.register_new("cursor", [
         BEVY_CURSOR_SYSTEM,
-        // BEVY_CURSOR_IMAGE,
+        BEVY_CURSOR_IMAGE,
+        BEVY_CURSOR_IMAGE_FLIP_X,
+        BEVY_CURSOR_IMAGE_FLIP_Y,
+        BEVY_CURSOR_IMAGE_RECT,
+        BEVY_CURSOR_IMAGE_HOTSPOT_X,
+        BEVY_CURSOR_IMAGE_HOTSPOT_Y,
     ], parse_cursor);
 }
 

--- a/examples/buttons_cursor.rs
+++ b/examples/buttons_cursor.rs
@@ -6,9 +6,10 @@ use bevy::{
     input_focus::tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
     prelude::*,
     text::TextWriter,
-    window::{PrimaryWindow, WindowTheme},
+    window::{PrimaryWindow, WindowTheme, Window, SystemCursorIcon},
 };
 use bevy_flair::prelude::*;
+use bevy_flair::core::components::DefaultCursorIcon;
 
 fn main() {
     App::new()
@@ -18,6 +19,7 @@ fn main() {
             TabNavigationPlugin,
             FlairPlugin,
         ))
+        .add_systems(Startup, set_default_cursor)
         .add_systems(Startup, setup)
         .add_systems(PostStartup, force_window_theme)
         .run();
@@ -25,6 +27,12 @@ fn main() {
 
 #[derive(Component)]
 struct DarkLightButton;
+
+fn set_default_cursor(mut commands: Commands, windows : Query<Entity, With<Window>>) {
+    for window in windows {
+        commands.entity(window).insert(DefaultCursorIcon(SystemCursorIcon::Help.into()));
+    }
+}
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     fn button() -> impl Bundle {

--- a/examples/buttons_cursor.rs
+++ b/examples/buttons_cursor.rs
@@ -1,0 +1,101 @@
+//! This examples illustrates how to create a button that changes color and text based on its
+//! interaction state.
+
+use bevy::{
+    input_focus::InputDispatchPlugin,
+    input_focus::tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
+    prelude::*,
+    text::TextWriter,
+    window::{PrimaryWindow, WindowTheme},
+};
+use bevy_flair::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            InputDispatchPlugin,
+            TabNavigationPlugin,
+            FlairPlugin,
+        ))
+        .add_systems(Startup, setup)
+        .add_systems(PostStartup, force_window_theme)
+        .run();
+}
+
+#[derive(Component)]
+struct DarkLightButton;
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    fn button() -> impl Bundle {
+        (Button, TabIndex::default(), children![Text::new("Button")])
+    }
+
+    fn dark_light_button() -> impl Bundle {
+        (
+            Button,
+            ClassList::new("dark-light-button"),
+            DarkLightButton,
+            children![Text::new("???TO_BE_REPLACED???")],
+        )
+    }
+
+    // ui camera
+    commands.spawn(Camera2d);
+
+    commands
+        .spawn((
+            Node::default(),
+            NodeStyleSheet::new(asset_server.load("buttons_cursor.css")),
+            ClassList::empty(),
+            TabGroup::new(0),
+        ))
+        .with_children(|root| {
+            root.spawn(button());
+            root.spawn(button());
+            root.spawn(button());
+            root.spawn(button());
+
+            root.spawn(dark_light_button())
+                .observe(dark_light_button_observer);
+        });
+}
+
+fn force_window_theme(
+    mut primary_window: Single<&mut Window, With<PrimaryWindow>>,
+    dark_light_button: Single<&Children, With<DarkLightButton>>,
+    mut text_writer: TextWriter<Text>,
+) {
+    if primary_window.window_theme.is_none() {
+        primary_window.window_theme = Some(WindowTheme::Light)
+    }
+    let mut text = text_writer.text(dark_light_button[0], 0);
+    text.clear();
+    text.push_str(if primary_window.window_theme == Some(WindowTheme::Dark) {
+        "Dark"
+    } else {
+        "Light"
+    });
+}
+
+fn dark_light_button_observer(
+    _trigger: On<Pointer<Click>>,
+    mut primary_window: Single<&mut Window, With<PrimaryWindow>>,
+    dark_light_button: Single<&Children, With<DarkLightButton>>,
+    mut text_writer: TextWriter<Text>,
+) {
+    let new_window_theme = match primary_window.window_theme {
+        Some(WindowTheme::Light) => WindowTheme::Dark,
+        Some(WindowTheme::Dark) => WindowTheme::Light,
+        None => WindowTheme::Dark,
+    };
+    primary_window.window_theme = Some(new_window_theme);
+
+    let mut text = text_writer.text(dark_light_button[0], 0);
+    text.clear();
+    text.push_str(if new_window_theme == WindowTheme::Dark {
+        "Dark"
+    } else {
+        "Light"
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,8 @@ bevy_app::plugin_group! {
     pub struct FlairPlugin {
         bevy_flair_core:::PropertyRegistryPlugin,
         bevy_flair_core:::ImplComponentPropertiesPlugin,
+        #[cfg(feature = "experimental_cursor_property")]
+        bevy_flair_core::components:::HoverCursorPlugin,
         bevy_flair_style:::FlairStylePlugin,
         bevy_flair_style:::FlairDefaultStyleAnimationsPlugin,
         bevy_flair_css_parser:::FlairCssParserPlugin,


### PR DESCRIPTION
Hi! This PR attempts to add support for the `cursor` CSS property.

---
### `bool` value parser
Though true 'booleans' are not part of the CSS specification, they are useful when defining custom properties.
It was added because it is used by the `-bevy-cursor-image-flip-x` and `-bevy-cursor-image-flip-y` properties.
```css
property-name: true;
property-name: false;
```

---
### `cursor` property
The main purpose of this PR: The `cursor` CSS property sets the cursor icon when the element is hovered.

`experimental_cursor_property` is the main feature which gates this addition. `experimental_cursor_custom` adds support for custom image cursor icons through the `bevy_window/custom_cursor` and `bevy_winit/custom_cursor` features.

`cursor` is a shorthand for `-bevy-cursor-system` or `-bevy-cursor-image`, depending on whether a system cursor name or url is given.
`-bevy-cursor-image-flip-x`, `-bevy-cursor-image-flip-y`, `-bevy-cursor-image-rect`, `-bevy-cursor-image-hotspot-x`, and `-bevy-cursor-image-hotspot-y` are also provided, which map to the fields in [`CustomCursorImage`](https://docs.rs/bevy/latest/bevy/window/struct.CustomCursorImage.html).

```css
cursor: pointer;
cursor: grabbing;
cursor: url("image.png");
-bevy-cursor-system: wait;
-bevy-cursor-system: zoom-in;
-bevy-cursor-image: url("cursor.png");
-bevy-cursor-image-flip-x: true;
-bevy-cursor-image-flip-y: false;
-bevy-cursor-image-rect: 0 0 48 48;
-bevy-cursor-image-hotspot-x: 24;
-bevy-cursor-image-hotspot-y: 24;
```

**Implementation:**
The `HoverCursorIcon` component is added to any entities targeted by a rule containing a cursor-related property. When a `HoverCursorIcon` entity is hovered (through [`Interaction`](https://docs.rs/bevy/latest/bevy/prelude/enum.Interaction.html)), the `HoveredCursorIcon` component containing the currently focused window's ID is added. The [`CursorIcon`](https://docs.rs/bevy/latest/bevy/window/enum.CursorIcon.html) and `ManagedCursorIcon` components are then added to the window.
When the `HoverCursorIcon` entity is unhovered, the `HoveredCursorIcon` component is removed, followed by the [`CursorItem`](https://docs.rs/bevy/latest/bevy/window/enum.CursorIcon.html) and `ManagedCursorIcon` components on the targeted window.

Because this may remove an existing [`CursorItem`](https://docs.rs/bevy/latest/bevy/window/enum.CursorIcon.html), a `DefaultCursorIcon` component has been added, which can be inserted into a window entity instead of [`CursorIcon`](https://docs.rs/bevy/latest/bevy/window/enum.CursorIcon.html). This will be the cursor icon used unless a `HoverCursorIcon` entity is actively being hovered. Since this is a very opinionated solution to the problem, some discussion is probably in order.

---
### `buttons_cursor` example
A copy of the `buttons` example, but using the `cursor` property.