### PR TITLE
Fix multiple animations with delay

### DIFF
--- a/crates/bevy_flair_style/src/components.rs
+++ b/crates/bevy_flair_style/src/components.rs
@@ -996,7 +996,7 @@ This can cause other issues. Is recommended to spawn nodes before StyleSystems::
             for (property_id, animation) in animations.iter_mut() {
                 let property_id = *property_id;
                 if !animation.can_be_ticked() {
-                    return;
+                    continue;
                 }
                 let was_pending = animation.state == AnimationState::Pending;
                 let was_running = was_pending || animation.state == AnimationState::Running;


### PR DESCRIPTION
After the animation system refactor, secondary delayed animations broke:
```css
animation:
  0.75s ease-out roll-in,
  0.75s ease-out 2s roll-out;
``` 
 It was a simple typo of `return` instead of `continue` in a loop, so when the first animation is finished and can't be ticked, none of subsequent animations got ticks