### PR TITLE
Allow transitions to overshoot (sample outside the [0, 1] range).

### DIFF
--- a/crates/bevy_flair_style/src/animations/transition.rs
+++ b/crates/bevy_flair_style/src/animations/transition.rs
@@ -199,27 +199,24 @@ impl Transition {
         // "* start value is the current value of the property in the running transition,
         //  * end value is the value of the property in the after-change style,"
 
-        if let Some(new_start) = replaced_transition
+        self.from = replaced_transition
             .interpolation_curve
-            .sample(easing_function_output)
-        {
-            self.from = new_start;
-        }
+            .sample_unchecked(easing_function_output);
 
         self.interpolation_curve =
             reflect.create_property_transition_curve(Some(self.from.clone()), self.to.clone());
     }
 
     /// Calculates the current value of the transitions using the easing and interpolation curves.
-    pub fn sample_value(&self) -> Option<ReflectValue> {
+    pub fn sample_value(&self) -> ReflectValue {
         let t = (self.timer.elapsed_secs() - self.initial_delay.as_secs_f32())
             / (self.duration.as_secs_f32());
         if t < 0.0 || self.state == TransitionState::Pending {
-            return Some(self.from.clone());
+            return self.from.clone();
         }
 
         let eased_t = self.easing_curve.sample_clamped(t);
-        self.interpolation_curve.sample(eased_t)
+        self.interpolation_curve.sample_unchecked(eased_t)
     }
 
     pub(crate) fn can_be_ticked(&self) -> bool {
@@ -279,24 +276,24 @@ mod tests {
         assert_eq!(transition.elapsed_secs(), 0.0);
 
         // Emits initial value
-        assert_eq!(transition.sample_value(), Some(ReflectValue::Float(0.0)));
+        assert_eq!(transition.sample_value(), ReflectValue::Float(0.0));
 
         // Ticking for zero seconds should mark the animation as Running
         transition.tick(Duration::ZERO);
 
         assert_eq!(transition.state, TransitionState::Running);
-        assert_eq!(transition.sample_value(), Some(ReflectValue::Float(0.0)));
+        assert_eq!(transition.sample_value(), ReflectValue::Float(0.0));
         assert_eq!(transition.elapsed_secs(), 0.0);
 
         transition.tick(HALF_SECOND);
 
         assert_eq!(transition.state, TransitionState::Running);
-        assert_eq!(transition.sample_value(), Some(ReflectValue::Float(5.0)));
+        assert_eq!(transition.sample_value(), ReflectValue::Float(5.0));
         assert_eq!(transition.elapsed_secs(), 0.5);
 
         transition.tick(HALF_SECOND);
         assert_eq!(transition.state, TransitionState::Finished);
-        assert_eq!(transition.sample_value(), Some(ReflectValue::Float(10.0)));
+        assert_eq!(transition.sample_value(), ReflectValue::Float(10.0));
         assert_eq!(transition.elapsed_secs(), 1.0);
     }
 
@@ -321,12 +318,12 @@ mod tests {
         assert_eq!(transition.duration, Duration::ZERO);
 
         // Emits initial value
-        assert_eq!(transition.sample_value(), Some(ReflectValue::Float(0.0)));
+        assert_eq!(transition.sample_value(), ReflectValue::Float(0.0));
 
         // Ticking for zero seconds should mark the animation as Finished
         transition.tick(Duration::ZERO);
 
         assert_eq!(transition.state, TransitionState::Finished);
-        assert_eq!(transition.sample_value(), None);
+        assert_eq!(transition.sample_value(), ReflectValue::Float(10.0));
     }
 }

--- a/crates/bevy_flair_style/src/animations/transition.rs
+++ b/crates/bevy_flair_style/src/animations/transition.rs
@@ -140,8 +140,7 @@ impl Transition {
         (self.timer.elapsed_secs() - self.initial_delay.as_secs_f32()).max(0.0)
     }
 
-    /// If this transition is active, meaning that it can produce values.
-    /// Calling [`sample_value`](self.sample_value) will return Some value.
+    /// Returns `true` if this transition is active.
     pub fn is_active(&self) -> bool {
         matches!(
             self.state,
@@ -209,14 +208,18 @@ impl Transition {
 
     /// Calculates the current value of the transitions using the easing and interpolation curves.
     pub fn sample_value(&self) -> ReflectValue {
-        let t = (self.timer.elapsed_secs() - self.initial_delay.as_secs_f32())
-            / (self.duration.as_secs_f32());
-        if t < 0.0 || self.state == TransitionState::Pending {
-            return self.from.clone();
+        match self.state {
+            TransitionState::Pending => self.from.clone(),
+            TransitionState::Finished | TransitionState::Canceled => self.to.clone(),
+            TransitionState::Running => {
+                let Some(elapsed) = self.timer.elapsed().checked_sub(self.initial_delay) else {
+                    return self.from.clone();
+                };
+                let t = elapsed.as_secs_f32() / (self.duration.as_secs_f32());
+                let eased_t = self.easing_curve.sample_clamped(t);
+                self.interpolation_curve.sample_unchecked(eased_t)
+            }
         }
-
-        let eased_t = self.easing_curve.sample_clamped(t);
-        self.interpolation_curve.sample_unchecked(eased_t)
     }
 
     pub(crate) fn can_be_ticked(&self) -> bool {
@@ -245,12 +248,18 @@ impl Transition {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{EasingFunction, Transition, TransitionOptions, TransitionState};
+    use crate::animations::ReflectAnimatable;
+    use bevy_flair_core::{ComponentPropertyId, ReflectValue};
+    use bevy_math::Vec2;
     use bevy_reflect::FromType;
+    use std::time::Duration;
 
     const ONE_SECOND: Duration = Duration::from_secs(1);
 
     const HALF_SECOND: Duration = Duration::from_millis(500);
+
+    const ONE_NANOSECOND: Duration = Duration::from_nanos(1);
 
     const DEFAULT_TRANSITION_OPTIONS: TransitionOptions = TransitionOptions {
         initial_delay: Duration::ZERO,
@@ -298,7 +307,33 @@ mod tests {
     }
 
     #[test]
-    fn zero_transition() {
+    fn easing_can_overshoot() {
+        let reflect_animatable_f32 = <ReflectAnimatable as FromType<f32>>::from_type();
+
+        let mut transition = Transition::new(
+            ComponentPropertyId::PLACEHOLDER,
+            Some(ReflectValue::Float(0.0)),
+            ReflectValue::Float(10.0),
+            &TransitionOptions {
+                // cubic-bezier(.17,.67,.33,1.5)
+                timing_function: EasingFunction::CubicBezier {
+                    p1: Vec2::new(0.17, 0.67),
+                    p2: Vec2::new(0.33, 1.5),
+                },
+                ..DEFAULT_TRANSITION_OPTIONS
+            },
+            &reflect_animatable_f32,
+        );
+
+        transition.tick(HALF_SECOND);
+
+        assert_eq!(transition.state, TransitionState::Running);
+        // The eased t in this interpolation curve is higher than 1.0, so the transition extrapolates
+        assert!(transition.sample_value().downcast_value::<f32>().unwrap() > 10.0);
+    }
+
+    #[test]
+    fn zero_duration_transition() {
         let reflect_animatable_f32 = <ReflectAnimatable as FromType<f32>>::from_type();
 
         let mut transition = Transition::new(
@@ -322,6 +357,47 @@ mod tests {
 
         // Ticking for zero seconds should mark the animation as Finished
         transition.tick(Duration::ZERO);
+
+        assert_eq!(transition.state, TransitionState::Finished);
+        assert_eq!(transition.sample_value(), ReflectValue::Float(10.0));
+    }
+
+    #[test]
+    fn nano_duration_transition() {
+        let reflect_animatable_f32 = <ReflectAnimatable as FromType<f32>>::from_type();
+
+        let mut transition = Transition::new(
+            ComponentPropertyId::PLACEHOLDER,
+            Some(ReflectValue::Float(0.0)),
+            ReflectValue::Float(10.0),
+            &TransitionOptions {
+                initial_delay: ONE_SECOND,
+                duration: Duration::from_nanos(2),
+                timing_function: EasingFunction::Linear,
+            },
+            &reflect_animatable_f32,
+        );
+
+        assert_eq!(transition.state, TransitionState::Pending);
+        assert_eq!(transition.sample_value(), ReflectValue::Float(0.0));
+
+        transition.tick(HALF_SECOND);
+
+        assert_eq!(transition.state, TransitionState::Pending);
+        assert_eq!(transition.sample_value(), ReflectValue::Float(0.0));
+
+        transition.tick(HALF_SECOND);
+
+        assert_eq!(transition.state, TransitionState::Running);
+        assert_eq!(transition.sample_value(), ReflectValue::Float(0.0));
+
+        transition.tick(ONE_NANOSECOND);
+
+        // The math should be correct even after one nanosecond.
+        assert_eq!(transition.state, TransitionState::Running);
+        assert_eq!(transition.sample_value(), ReflectValue::Float(5.0));
+
+        transition.tick(ONE_NANOSECOND);
 
         assert_eq!(transition.state, TransitionState::Finished);
         assert_eq!(transition.sample_value(), ReflectValue::Float(10.0));

--- a/crates/bevy_flair_style/src/components/properties.rs
+++ b/crates/bevy_flair_style/src/components/properties.rs
@@ -306,9 +306,8 @@ impl StyleProperties {
         for (&property_id, transition) in &self.transitions {
             match transition.state {
                 TransitionState::Pending | TransitionState::Running => {
-                    if let Some(value) = transition.sample_value() {
-                        self.pending_computed_animation_values[property_id] = value.into();
-                    }
+                    let value = transition.sample_value();
+                    self.pending_computed_animation_values[property_id] = value.into();
                 }
                 TransitionState::Finished | TransitionState::Canceled => {
                     self.pending_computed_animation_values[property_id] =


### PR DESCRIPTION
This is a requirement per [CSS Transitions 1 § 4]:

> The specific interpolation procedure to be used is defined by the
property’s animation type.

where *interpolation* links to [CSS Values 4 § 3]:

> *interpolation*
>
> Given two property values VA and VB, produces an intermediate value
> Vresult at a distance of *p* along the interval between VA and VB such
> that *p* = 0 produces VA and *p* = 1 produces VB.
>
> The range of *p* is (−∞, ∞) due to the effect of timing functions. As
> a result, this procedure must also define extrapolation behavior for *p*
> outside [0, 1].

The last sentence implies that interpolation between the from-value at *t* = 0 and the to-value at *t* = 1 must not be clamped to *t* = [0, 1].

It turns out that Bevy supports overshoots via
`Curve::sample_unchecked`, though [the documentation] discourages it:

> This is the unchecked version of sampling, which should only be used
> if the sample time `t` is already known to lie within the curve's
> domain.
>
> Values sampled from outside of a curve's domain are generally
> considered invalid; data which is nonsensical or otherwise useless may
> be returned in such a circumstance, and extrapolation beyond a curve's
> domain should not be relied upon.

I consider this language in the documentation to be a bug in Bevy. Overshoots are a core principle of animation, and they work just fine in browsers ([live example]). Bevy shouldn't be discouraging developers from using overshoots.

In any case, this patch switches `bevy_flair` to use `Curve::sample_unchecked` to sample the property that is the subject of each transition. (The supplied easing curve continues to be sampled using `Curve::sample`, because the *transition time* must be clamped to the [0, 1] interval.) From my testing, this allows overshoots to "just work" and makes `bevy_flair` match the CSS specification.

[CSS Transitions 1 § 4]: https://www.w3.org/TR/css-transitions-1/#application

[CSS Values 4 § 3]: https://www.w3.org/TR/css-values-4/#interpolation

[the documentation]: https://docs.rs/bevy_math/latest/bevy_math/curve/trait.Curve.html#tymethod.sample_unchecked

[live example]: https://cubic-bezier.com/#.17,.67,.33,1.5