### PR TITLE
Keep a pending Reset when recalculate_style is requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- `StyleMarkers::recalculate_style` now keeps a pending `Reset` instead of
+  panicking in debug builds (or silently downgrading the reset to
+  `CalculateStyle` in release builds, skipping the animation/transition
+  reset). The combination occurs legitimately in a single frame: an entity
+  spawned this frame (or whose effective stylesheet just resolved) still sits
+  in `Reset` when `mark_entities_for_recalculation` sweeps it in as the
+  sibling / descendant / ancestor of a changed entity via
+  `RecalculateOnChangeFlags`.
+
 ## [0.8.0] - 22-Jun-2026
 
 ### Added

--- a/crates/bevy_flair_style/src/components/marker.rs
+++ b/crates/bevy_flair_style/src/components/marker.rs
@@ -121,6 +121,17 @@ impl StyleMarkers {
     #[track_caller]
     pub fn recalculate_style(&mut self) {
         detailed_trace!(self, "recalculate_style");
+
+        // A pending `Reset` already implies a full style recalculation
+        // (`Reset`'s next system is `CalculateStyle`), so keep the stronger
+        // pending state. This combination occurs legitimately in one frame:
+        // an entity whose effective stylesheet just resolved (`Reset`) can be
+        // marked for recalculation as the sibling / descendant / ancestor of
+        // a changed entity via `RecalculateOnChangeFlags` in
+        // `mark_entities_for_recalculation`.
+        if self.current_system == StyleSystem::Reset {
+            return;
+        }
         debug_assert!(
             matches!(
                 self.current_system,
@@ -224,4 +235,23 @@ impl StyleMarkers {
         finish_apply_pending_properties,
         ApplyPendingProperties
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An entity whose effective stylesheet just resolved sits in `Reset`;
+    /// being marked for recalculation in the same frame (e.g. as the sibling /
+    /// descendant / ancestor of a changed entity via
+    /// `RecalculateOnChangeFlags`) must keep the stronger pending reset
+    /// instead of panicking (debug builds) or downgrading it to
+    /// `CalculateStyle` (release builds, which skipped the reset work).
+    #[test]
+    fn recalculate_style_keeps_a_pending_reset() {
+        let mut markers = StyleMarkers::default();
+        markers.reset();
+        markers.recalculate_style();
+        assert!(markers.needs_reset());
+    }
 }


### PR DESCRIPTION
## The problem

`StyleMarkers::recalculate_style` asserts the current state is `None` or `CalculateStyle`. But an entity can legitimately still sit in `Reset` when a recalculation request arrives in the same frame:

- `StyleSystem`'s `#[default]` variant is `Reset`, so every freshly spawned styled entity starts there (and `set_effective_style_sheet` also resets an entity whose effective stylesheet just resolved or changed), and
- `mark_entities_for_recalculation` calls `recalculate_style()` not just on entities whose `StyleData` / inline style changed, but on their **siblings / descendants / ancestors** via `RecalculateOnChangeFlags`.

So "spawn a widget subtree, and in the same frame change a style-affecting property on a relative" — an ordinary UI-construction frame — sweeps the just-spawned entity (still `Reset`) into `to_be_marked`, and `recalculate_style()` hits the `debug_assert` at `systems.rs:516`. In our app (a Bevy viewer with a large flair-styled UI) this crashes debug builds a few seconds after startup, timing-dependent.

In **release** builds the assert compiles out and the pending `Reset` was silently *downgraded* to `CalculateStyle` — skipping the animation/transition reset that `reset()` promises — so the situation was quietly mishandled there too, not just noisy in debug.

## The fix

`Reset` already implies a full recalculation (`into_next_system` maps `Reset → CalculateStyle`), so a recalculation request on a `Reset` entity keeps the stronger pending state and returns early — the exact guard `set_needs_resolve_property_values` and `set_needs_compute_property_values` already apply for `Reset` ("it will end up there eventually"). The assert still rejects requests landing mid-pipeline (`ResolvePropertyValues` onward), which remain genuinely invalid.

Includes a regression test and a changelog entry. All existing tests pass.